### PR TITLE
get_app_icon_html and tests

### DIFF
--- a/timeline/templatetags/timeline_tags.py
+++ b/timeline/templatetags/timeline_tags.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils.timezone import localtime
 
 from djangoplugins.models import Plugin
+from projectroles.plugins import ProjectAppPluginPoint
 
 from timeline.api import TimelineAPI
 from timeline.models import ProjectEvent
@@ -83,6 +84,10 @@ def get_app_icon_html(event, plugin_lookup):
         icon = ICON_PROJECTROLES
     else:
         plugin_name = event.plugin if event.plugin else event.app
+        if plugin_name in plugin_lookup.keys():
+            plugin = plugin_lookup[plugin_name]
+            if not isinstance(plugin, ProjectAppPluginPoint):
+                url_kwargs['project'] = None
         if plugin_name in plugin_lookup.keys():
             plugin = plugin_lookup[plugin_name]
             entry_point = getattr(plugin, 'entry_point_url_id', None)

--- a/timeline/templatetags/timeline_tags.py
+++ b/timeline/templatetags/timeline_tags.py
@@ -86,8 +86,15 @@ def get_app_icon_html(event, plugin_lookup):
         if plugin_name in plugin_lookup.keys():
             plugin = plugin_lookup[plugin_name]
             entry_point = getattr(plugin, 'entry_point_url_id', None)
-            if entry_point:
-                url = reverse(entry_point, kwargs=url_kwargs)
+            if entry_point in plugin_lookup.items:
+                try:
+                    url = reverse(entry_point, kwargs=url_kwargs)
+                except Exception as ex:
+                    logger.error(
+                        'Unable to get URL for plugin "{}": {}'.format(
+                            entry_point, ex
+                        )
+                    )
             title = plugin.title
             if getattr(plugin, 'icon', None):
                 icon = plugin.icon

--- a/timeline/tests/test_templatetags.py
+++ b/timeline/tests/test_templatetags.py
@@ -198,20 +198,7 @@ class TestTemplateTags(
         self.assertIn(plugin.icon, ret)
         self.assertIn(plugin.title, ret)
         self.assertIn(url, ret)
-
-    def test_get_app_icon_html_timeline(self):
-        """Test get_app_icon_html() on event from the timeline app"""
-        event = self._make_event(
-            project=self.project,
-            app='timeline',
-            user=self.user_owner,
-            event_name=TEST_EVENT_NAME,
-            description=TEST_EVENT_DESC,
-        )
-        ret = tags.get_app_icon_html(event, self.plugin_lookup)
-        self.assertIn(tags.ICON_TIMELINE, ret)
-        self.assertIn('Timeline', ret)
-        self.assertIn('href=', ret)
+        self.assertIn(plugin.entry_point_url_id, ret)
 
     def test_get_app_icon_html_invalid_plugin(self):
         """Test get_app_icon_html() on event from an invalid plugin"""

--- a/timeline/tests/test_templatetags.py
+++ b/timeline/tests/test_templatetags.py
@@ -180,6 +180,39 @@ class TestTemplateTags(
         self.assertIn(plugin.title, ret)
         self.assertIn(url, ret)
 
+    def test_get_app_icon_html_example_site_app(self):
+        """Test get_app_icon_html() on event from an app plugin"""
+        event = self._make_event(
+            project=self.project,
+            app='example_site_app',
+            user=self.user_owner,
+            event_name=TEST_EVENT_NAME,
+            description=TEST_EVENT_DESC,
+        )
+        plugin = get_app_plugin('example_site_app')
+        url = reverse(
+            plugin.entry_point_url_id,
+            kwargs={'project': self.project.sodar_uuid},
+        )
+        ret = tags.get_app_icon_html(event, self.plugin_lookup)
+        self.assertIn(plugin.icon, ret)
+        self.assertIn(plugin.title, ret)
+        self.assertIn(url, ret)
+
+    def test_get_app_icon_html_timeline(self):
+        """Test get_app_icon_html() on event from the timeline app"""
+        event = self._make_event(
+            project=self.project,
+            app='timeline',
+            user=self.user_owner,
+            event_name=TEST_EVENT_NAME,
+            description=TEST_EVENT_DESC,
+        )
+        ret = tags.get_app_icon_html(event, self.plugin_lookup)
+        self.assertIn(tags.ICON_TIMELINE, ret)
+        self.assertIn('Timeline', ret)
+        self.assertIn('href=', ret)
+
     def test_get_app_icon_html_invalid_plugin(self):
         """Test get_app_icon_html() on event from an invalid plugin"""
         event = self._make_event(


### PR DESCRIPTION
Task #1057 get_app_icon_html().
 - Changed a little bit timeline/templatetags/timeline_tags.py
 - Added 2 tests in timeline/tests/test_templatetsgs.py
 ---

Will be happy for any feedback


> Was: ![Screenshot from 2022-12-08 15-47-22](https://user-images.githubusercontent.com/86564271/206493733-1c08f612-095f-4270-974b-62594858ec59.png)
> Became: ![Screenshot from 2022-12-08 16-47-41](https://user-images.githubusercontent.com/86564271/206493986-c08bb8a4-a2c5-4a15-b2c6-25959c40540b.png)

P.s.
I've also made changes on another tasks at my branch, so I hope, I do not push other files.


