### PR TITLE
Prevent sending invites to local users if local users are disabled

### DIFF
--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -962,7 +962,7 @@ class ProjectInviteForm(SODARModelForm):
         domain = user_email[user_email.find('@') + 1 :]
         domain_list = [
             getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN'),
-            getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN')
+            getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN'),
         ]
         if (
             not settings.PROJECTROLES_ALLOW_LOCAL_USERS

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -961,8 +961,8 @@ class ProjectInviteForm(SODARModelForm):
         user_email = self.cleaned_data.get('email')
         domain = user_email[user_email.find('@') + 1 :]
         domain_list = [
-            getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN'),
-            getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN'),
+            getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN', None),
+            getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN', None),
         ]
         if (
             not settings.PROJECTROLES_ALLOW_LOCAL_USERS

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -745,28 +745,6 @@ class RoleAssignmentForm(SODARModelForm):
             if existing_as and existing_as.role == role:
                 self.add_error('role', 'Role already assigned to user')
 
-        # Local users check
-        user_email = self.cleaned_data.get('user').email
-        domain = user_email[user_email.find('@') + 1 :]
-        allow_local_users = getattr(
-            settings, 'PROJECTROLES_ALLOW_LOCAL_USERS', True
-        )
-        enable_saml = getattr(settings, 'ENABLE_SAML', False)
-        domain_list = getattr(
-            settings, 'AUTH_LDAP_USERNAME_DOMAIN', []
-        ) + getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN', [])
-        if (
-            not allow_local_users
-            and not enable_saml
-            and domain not in domain_list
-        ):
-            self.add_error(
-                'user',
-                'Local users not allowed, email domain {} not recognized for LDAP users'.format(
-                    domain
-                ),
-            )
-
         # Delegate checks
         if role.name == PROJECT_ROLE_DELEGATE:
             del_limit = getattr(settings, 'PROJECTROLES_DELEGATE_LIMIT', 1)
@@ -978,6 +956,28 @@ class ProjectInviteForm(SODARModelForm):
             )
         except ProjectInvite.DoesNotExist:
             pass
+
+        # Local users check
+        user_email = self.cleaned_data.get('email')
+        domain = user_email[user_email.find('@') + 1 :]
+        allow_local_users = getattr(
+            settings, 'PROJECTROLES_ALLOW_LOCAL_USERS', False
+        )
+        enable_saml = getattr(settings, 'ENABLE_SAML', False)
+        domain_list = getattr(
+            settings, 'AUTH_LDAP_USERNAME_DOMAIN', []
+        ) + getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN', [])
+        if (
+            not allow_local_users
+            and not enable_saml
+            and domain not in domain_list
+        ):
+            self.add_error(
+                'email',
+                'Local users not allowed, email domain {} not recognized for LDAP users'.format(
+                    domain
+                ),
+            )
 
         # Delegate checks
         role = self.cleaned_data.get('role')

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -964,14 +964,14 @@ class ProjectInviteForm(SODARModelForm):
                 user_email[user_email.find('@') + 1 :].split('.')[0].lower()
             )
             domain_list = [
-                getattr(settings, 'ALT_LDAP_DOMAINS', ''),
+                getattr(settings, 'LDAP_ALT_DOMAINS', ''),
                 getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN', ''),
                 getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN', ''),
             ]
             if (
                 not settings.PROJECTROLES_ALLOW_LOCAL_USERS
                 and not settings.ENABLE_SAML
-                and domain not in [d.lower() for d in domain_list]
+                and any(domain in d for d in domain_list)
             ):
                 self.add_error(
                     'email',

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -963,15 +963,14 @@ class ProjectInviteForm(SODARModelForm):
             domain = (
                 user_email[user_email.find('@') + 1 :].split('.')[0].lower()
             )
-            domain_list = [
-                getattr(settings, 'LDAP_ALT_DOMAINS', ''),
+            domain_list = getattr(settings, 'LDAP_ALT_DOMAINS', []) + [
                 getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN', ''),
                 getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN', ''),
             ]
             if (
                 not settings.PROJECTROLES_ALLOW_LOCAL_USERS
                 and not settings.ENABLE_SAML
-                and any(domain in d for d in domain_list)
+                and not any(domain in d.lower() for d in domain_list)
             ):
                 self.add_error(
                     'email',

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -960,23 +960,19 @@ class ProjectInviteForm(SODARModelForm):
         # Local users check
         user_email = self.cleaned_data.get('email')
         domain = user_email[user_email.find('@') + 1 :]
-        allow_local_users = getattr(
-            settings, 'PROJECTROLES_ALLOW_LOCAL_USERS', False
-        )
-        enable_saml = getattr(settings, 'ENABLE_SAML', False)
-        domain_list = getattr(
-            settings, 'AUTH_LDAP_USERNAME_DOMAIN', []
-        ) + getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN', [])
+        domain_list = [
+            getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN'),
+            getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN')
+        ]
         if (
-            not allow_local_users
-            and not enable_saml
+            not settings.PROJECTROLES_ALLOW_LOCAL_USERS
+            and not settings.ENABLE_SAML
             and domain not in domain_list
         ):
             self.add_error(
                 'email',
-                'Local users not allowed, email domain {} not recognized for LDAP users'.format(
-                    domain
-                ),
+                'Local users not allowed, email domain {} not recognized for '
+                'LDAP users'.format(domain),
             )
 
         # Delegate checks

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -960,17 +960,20 @@ class ProjectInviteForm(SODARModelForm):
         # Local users check
         try:
             user_email = self.cleaned_data.get('email')
-            domain = (
-                user_email[user_email.find('@') + 1 :].split('.')[0].lower()
-            )
-            domain_list = getattr(settings, 'LDAP_ALT_DOMAINS', []) + [
+            domain = user_email[user_email.find('@') + 1 :]
+            domain_list = [
                 getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN', ''),
                 getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN', ''),
             ]
             if (
                 not settings.PROJECTROLES_ALLOW_LOCAL_USERS
                 and not settings.ENABLE_SAML
-                and not any(domain in d.lower() for d in domain_list)
+                and domain
+                not in [
+                    x.lower() for x in getattr(settings, 'LDAP_ALT_DOMAINS', [])
+                ]
+                and domain.split('.')[0].lower()
+                not in [x.lower() for x in domain_list]
             ):
                 self.add_error(
                     'email',

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -961,8 +961,8 @@ class ProjectInviteForm(SODARModelForm):
         user_email = self.cleaned_data.get('email')
         domain = user_email[user_email.find('@') + 1 :]
         domain_list = [
-            getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN', None),
-            getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN', None),
+            getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN', ''),
+            getattr(settings, 'AUTH_LDAP2_USERNAME_DOMAIN', ''),
         ]
         if (
             not settings.PROJECTROLES_ALLOW_LOCAL_USERS

--- a/projectroles/templatetags/projectroles_tags.py
+++ b/projectroles/templatetags/projectroles_tags.py
@@ -190,7 +190,7 @@ def get_login_info():
             ret += ' or ' + settings.AUTH_LDAP2_DOMAIN_PRINTABLE
         ret += (
             ' account. Enter your user name as <code>username@{}'
-            '</code>'.format(settings.AUTH_LDAP_USERNAME_DOMAIN)
+            '</code>'.format(getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN', ''))
         )
         if (
             settings.ENABLE_LDAP_SECONDARY

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -3123,23 +3123,31 @@ class TestProjectInviteCreateView(
             )
         self.assertEqual(response.status_code, 404)
 
-    # def test_local_users_not_allowed(self):
-    #     """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS = False"""
-    #     with self.settings(PROJECTROLES_ALLOW_LOCAL_USERS=False, ENABLE_SAML=False, AUTH_LDAP_USERNAME_DOMAIN=['example.com']):
-    #         with self.login(self.user):
-    #             response = self.client.post(
-    #                 reverse(
-    #                     'projectroles:invite_create',
-    #                     kwargs={'project': self.project.sodar_uuid},
-    #                 ),
-    #                 data={
-    #                     'email': INVITE_EMAIL,
-    #                     'project': self.project.pk,
-    #                     'role': self.role_contributor.pk,
-    #                 },
-    #             )
-    #         self.assertEqual(response.status_code, 200)
-    #         self.assertContains(response, 'is already registered')
+    @override_settings(
+        PROJECTROLES_ALLOW_LOCAL_USERS=False,
+        ENABLE_SAML=False,
+        AUTH_LDAP_USERNAME_DOMAIN=['example.com'],
+    )
+    def test_local_users_not_allowed(self):
+        """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS = False"""
+        values = {
+            'email': INVITE_EMAIL,
+            'project': self.project.pk,
+            'role': self.role_contributor.pk,
+        }
+        with self.login(self.user):
+            response = self.client.post(
+                reverse(
+                    'projectroles:invite_create',
+                    kwargs={'project': self.project.sodar_uuid},
+                ),
+                values,
+            )
+        self.assertEqual(response.status_code, 302)
+        invite = ProjectInvite.objects.get(
+            project=self.project, email=INVITE_EMAIL, active=True
+        )
+        self.assertIsNotNone(invite)
 
     def test_create_invite(self):
         """Test ProjectInvite creation"""

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -3123,6 +3123,24 @@ class TestProjectInviteCreateView(
             )
         self.assertEqual(response.status_code, 404)
 
+    # def test_local_users_not_allowed(self):
+    #     """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS = False"""
+    #     with self.settings(PROJECTROLES_ALLOW_LOCAL_USERS=False, ENABLE_SAML=False, AUTH_LDAP_USERNAME_DOMAIN=['example.com']):
+    #         with self.login(self.user):
+    #             response = self.client.post(
+    #                 reverse(
+    #                     'projectroles:invite_create',
+    #                     kwargs={'project': self.project.sodar_uuid},
+    #                 ),
+    #                 data={
+    #                     'email': INVITE_EMAIL,
+    #                     'project': self.project.pk,
+    #                     'role': self.role_contributor.pk,
+    #                 },
+    #             )
+    #         self.assertEqual(response.status_code, 200)
+    #         self.assertContains(response, 'is already registered')
+
     def test_create_invite(self):
         """Test ProjectInvite creation"""
         self.assertEqual(ProjectInvite.objects.all().count(), 0)

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -3128,7 +3128,7 @@ class TestProjectInviteCreateView(
         ENABLE_SAML=False,
     )
     def test_local_users_not_allowed(self):
-        """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS = False"""
+        """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS=False"""
         values = {
             'email': INVITE_EMAIL,
             'project': self.project.pk,
@@ -3178,6 +3178,33 @@ class TestProjectInviteCreateView(
     )
     def test_local_users_email_domain(self):
         """Test ProjectInvite creation for local users with email domain in AUTH_LDAP_USERNAME_DOMAIN"""
+        values = {
+            'email': INVITE_EMAIL,
+            'project': self.project.pk,
+            'role': self.role_contributor.pk,
+        }
+        with self.login(self.user):
+            response = self.client.post(
+                reverse(
+                    'projectroles:invite_create',
+                    kwargs={'project': self.project.sodar_uuid},
+                ),
+                values,
+            )
+        self.assertEqual(response.status_code, 302)
+        invite = ProjectInvite.objects.get(
+            project=self.project, email=INVITE_EMAIL, active=True
+        )
+        self.assertIsNotNone(invite)
+
+    @override_settings(
+        PROJECTROLES_ALLOW_LOCAL_USERS=False,
+        ENABLE_SAML=False,
+        ENABLE_LDAP=True,
+        LDAP_ALT_DOMAINS=['example.com'],
+    )
+    def test_local_users_email_domain_ldap(self):
+        """Test ProjectInvite creation for local users with email domain in LDAP_ALT_DOMAINS"""
         values = {
             'email': INVITE_EMAIL,
             'project': self.project.pk,

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -3126,7 +3126,6 @@ class TestProjectInviteCreateView(
     @override_settings(
         PROJECTROLES_ALLOW_LOCAL_USERS=False,
         ENABLE_SAML=False,
-        AUTH_LDAP_USERNAME_DOMAIN='',
     )
     def test_local_users_not_allowed(self):
         """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS = False"""
@@ -3149,7 +3148,6 @@ class TestProjectInviteCreateView(
     @override_settings(
         PROJECTROLES_ALLOW_LOCAL_USERS=True,
         ENABLE_SAML=False,
-        AUTH_LDAP_USERNAME_DOMAIN='',
     )
     def test_local_users_allowed(self):
         """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS = True"""
@@ -3175,7 +3173,8 @@ class TestProjectInviteCreateView(
     @override_settings(
         PROJECTROLES_ALLOW_LOCAL_USERS=False,
         ENABLE_SAML=False,
-        AUTH_LDAP_USERNAME_DOMAIN='example.com',
+        ENABLE_LDAP=True,
+        AUTH_LDAP_USERNAME_DOMAIN='EXAMPLE',
     )
     def test_local_users_email_domain(self):
         """Test ProjectInvite creation for local users with email domain in AUTH_LDAP_USERNAME_DOMAIN"""

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -3126,7 +3126,7 @@ class TestProjectInviteCreateView(
     @override_settings(
         PROJECTROLES_ALLOW_LOCAL_USERS=False,
         ENABLE_SAML=False,
-        AUTH_LDAP_USERNAME_DOMAIN=[],
+        AUTH_LDAP_USERNAME_DOMAIN='',
     )
     def test_local_users_not_allowed(self):
         """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS = False"""
@@ -3149,7 +3149,7 @@ class TestProjectInviteCreateView(
     @override_settings(
         PROJECTROLES_ALLOW_LOCAL_USERS=True,
         ENABLE_SAML=False,
-        AUTH_LDAP_USERNAME_DOMAIN=[],
+        AUTH_LDAP_USERNAME_DOMAIN='',
     )
     def test_local_users_allowed(self):
         """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS = True"""
@@ -3175,7 +3175,7 @@ class TestProjectInviteCreateView(
     @override_settings(
         PROJECTROLES_ALLOW_LOCAL_USERS=False,
         ENABLE_SAML=False,
-        AUTH_LDAP_USERNAME_DOMAIN=['example.com'],
+        AUTH_LDAP_USERNAME_DOMAIN='example.com',
     )
     def test_local_users_email_domain(self):
         """Test ProjectInvite creation for local users with email domain in AUTH_LDAP_USERNAME_DOMAIN"""

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -3126,10 +3126,59 @@ class TestProjectInviteCreateView(
     @override_settings(
         PROJECTROLES_ALLOW_LOCAL_USERS=False,
         ENABLE_SAML=False,
-        AUTH_LDAP_USERNAME_DOMAIN=['example.com'],
+        AUTH_LDAP_USERNAME_DOMAIN=[],
     )
     def test_local_users_not_allowed(self):
         """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS = False"""
+        values = {
+            'email': INVITE_EMAIL,
+            'project': self.project.pk,
+            'role': self.role_contributor.pk,
+        }
+        with self.login(self.user):
+            response = self.client.post(
+                reverse(
+                    'projectroles:invite_create',
+                    kwargs={'project': self.project.sodar_uuid},
+                ),
+                values,
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(ProjectInvite.objects.all().count(), 0)
+
+    @override_settings(
+        PROJECTROLES_ALLOW_LOCAL_USERS=True,
+        ENABLE_SAML=False,
+        AUTH_LDAP_USERNAME_DOMAIN=[],
+    )
+    def test_local_users_allowed(self):
+        """Test ProjectInvite creation for local users with PROJECTROLES_ALLOW_LOCAL_USERS = True"""
+        values = {
+            'email': INVITE_EMAIL,
+            'project': self.project.pk,
+            'role': self.role_contributor.pk,
+        }
+        with self.login(self.user):
+            response = self.client.post(
+                reverse(
+                    'projectroles:invite_create',
+                    kwargs={'project': self.project.sodar_uuid},
+                ),
+                values,
+            )
+        self.assertEqual(response.status_code, 302)
+        invite = ProjectInvite.objects.get(
+            project=self.project, email=INVITE_EMAIL, active=True
+        )
+        self.assertIsNotNone(invite)
+
+    @override_settings(
+        PROJECTROLES_ALLOW_LOCAL_USERS=False,
+        ENABLE_SAML=False,
+        AUTH_LDAP_USERNAME_DOMAIN=['example.com'],
+    )
+    def test_local_users_email_domain(self):
+        """Test ProjectInvite creation for local users with email domain in AUTH_LDAP_USERNAME_DOMAIN"""
         values = {
             'email': INVITE_EMAIL,
             'project': self.project.pk,


### PR DESCRIPTION
Issue #616 
Done:
- [x] Added check in ProjectInviteForm.clean()
- [x] Added tests in TestProjectInviteCreateView