### PR TITLE
Projectroles/post search

### DIFF
--- a/projectroles/templates/projectroles/search_advanced.html
+++ b/projectroles/templates/projectroles/search_advanced.html
@@ -18,10 +18,11 @@
 </div>
 
 <div class="container-fluid sodar-page-container">
- <form method="get" action="{% url 'projectroles:search' %}">
+ <form method="POST">
+   {% csrf_token %}
    <div class="form-group">
-     <label for="id_m" class="col-form-label">Search Terms</label>
-     <textarea name="m" cols="40" rows="8" class=" form-control" id="id_m"></textarea>
+     <label for="search_terms" class="col-form-label">Search Terms</label>
+     <textarea name="search_terms" cols="40" rows="8" class=" form-control" id="search_terms"></textarea>
      <small class="form-text text-muted">
        Enter one or more search terms separated by line breaks.
        Terms shorter than 3 characters will be ignored.

--- a/projectroles/templates/projectroles/search_advanced.html
+++ b/projectroles/templates/projectroles/search_advanced.html
@@ -18,32 +18,32 @@
 </div>
 
 <div class="container-fluid sodar-page-container">
- <form method="POST">
-   {% csrf_token %}
-   <div class="form-group">
-     <label for="search_terms" class="col-form-label">Search Terms</label>
-     <textarea name="search_terms" cols="40" rows="8" class=" form-control" id="search_terms"></textarea>
-     <small class="form-text text-muted">
-       Enter one or more search terms separated by line breaks.
-       Terms shorter than 3 characters will be ignored.
-     </small>
-   </div>
-   <div class="form-group">
-     <label for="id_k" class="col-form-label">Keywords</label>
-     <input type="text" name="k" class="form-control"
-            placeholder="key:value key2:value" id="id_k" />
-     <small class="form-text text-muted">
-       Enter keywords as key/value pairs separated by spaces (optional)
-     </small>
-   </div>
-   <div class="row">
+  <form method="POST">
+    {% csrf_token %}
+    <div class="form-group">
+      <label for="id_m" class="col-form-label">Search Terms</label>
+      <textarea name="m" cols="40" rows="8" class=" form-control" id="id_m"></textarea>
+      <small class="form-text text-muted">
+        Enter one or more search terms separated by line breaks.
+        Terms shorter than 3 characters will be ignored.
+      </small>
+    </div>
+    <div class="form-group">
+      <label for="id_k" class="col-form-label">Keywords</label>
+      <input type="text" name="k" class="form-control"
+             placeholder="key:value key2:value" id="id_k" />
+      <small class="form-text text-muted">
+        Enter keywords as key/value pairs separated by spaces (optional)
+      </small>
+    </div>
+    <div class="row">
       <div class="btn-group ml-auto" role="group">
         <button type="submit" class="btn btn-primary">
           <i class="iconify" data-icon="mdi:search"></i> Search
         </button>
       </div>
     </div>
- </form>
+  </form>
 </div>
 
 {% endblock projectroles %}

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -269,10 +269,9 @@ class TestProjectSearchView(
         )
 
         with self.login(self.user):
-            response = self.client.get(
-                reverse('projectroles:search')
-                + '?'
-                + urlencode({'m': 'testproject\r\nxxx', 'k': ''})
+            response = self.client.post(
+                reverse('projectroles:search_advanced'),
+                data={'m': 'testproject\r\nxxx', 'k': ''},
             )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -295,10 +294,9 @@ class TestProjectSearchView(
         )
 
         with self.login(self.user):
-            response = self.client.get(
-                reverse('projectroles:search')
-                + '?'
-                + urlencode({'m': 'testproject\r\nxx', 'k': ''})
+            response = self.client.post(
+                reverse('projectroles:search_advanced'),
+                data={'m': 'testproject\r\nxx', 'k': ''},
             )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['search_terms'], ['testproject'])
@@ -317,10 +315,9 @@ class TestProjectSearchView(
         )
 
         with self.login(self.user):
-            response = self.client.get(
-                reverse('projectroles:search')
-                + '?'
-                + urlencode({'m': 'testproject\r\n\r\nxxx', 'k': ''})
+            response = self.client.post(
+                reverse('projectroles:search_advanced'),
+                data={'m': 'testproject\r\nxxx', 'k': ''},
             )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -331,10 +328,9 @@ class TestProjectSearchView(
     def test_render_advanced_dupe(self):
         """Test input from advanced search with a duplicate term"""
         with self.login(self.user):
-            response = self.client.get(
-                reverse('projectroles:search')
-                + '?'
-                + urlencode({'m': 'xxx\r\nxxx', 'k': ''})
+            response = self.client.post(
+                reverse('projectroles:search_advanced'),
+                data={'m': 'xxx\r\nxxx', 'k': ''},
             )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['search_terms'], ['xxx'])

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -7,7 +7,7 @@ import ssl
 import urllib.request
 
 from ipaddress import ip_address, ip_network
-from urllib.parse import unquote_plus
+from urllib.parse import unquote_plus, urlencode
 
 from django.apps import apps
 from django.conf import settings
@@ -751,6 +751,16 @@ class ProjectAdvancedSearchView(
     """View for displaying advanced search form"""
 
     template_name = 'projectroles/search_advanced.html'
+
+    def post(self, request, *args, **kwargs):
+        search_terms = request.POST.get('search_terms')
+        if not search_terms:
+            messages.error(request, 'No search terms provided.')
+            return redirect(reverse('home'))
+        params = {'s': search_terms}
+        reverse_url = reverse('projectroles:search')
+        reverse_url = '{}?{}'.format(reverse_url, urlencode(params))
+        return redirect(reverse_url)
 
 
 # Project Editing Views --------------------------------------------------------

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -682,27 +682,17 @@ class ProjectSearchResultsView(
         keyword_input = []
         search_keywords = {}
 
-        if self.request.GET.get('m'):  # Multi search
-            search_terms = [
-                t.strip()
-                for t in self.request.GET['m'].strip().split('\r\n')
-                if len(t.strip()) >= 3
-            ]
-            if self.request.GET.get('k'):
-                keyword_input = self.request.GET['k'].strip().split(' ')
-            search_input = ''  # Clears input for basic search
-        else:  # Single term search
-            search_input = self.request.GET.get('s').strip()
-            search_split = search_input.split(' ')
-            search_term = search_split[0].strip()
-            for i in range(1, len(search_split)):
-                s = search_split[i].strip()
-                if ':' in s:
-                    keyword_input.append(s)
-                elif s != '':
-                    search_term += ' ' + s.lower()
-            if search_term:
-                search_terms = [search_term]
+        search_input = self.request.GET.get('s').strip()
+        search_split = search_input.split(' ')
+        search_term = search_split[0].strip()
+        for i in range(1, len(search_split)):
+            s = search_split[i].strip()
+            if ':' in s:
+                keyword_input.append(s)
+            elif s != '':
+                search_term += ' ' + s.lower()
+        if search_term:
+            search_terms = [search_term]
         search_terms = list(dict.fromkeys(search_terms))  # Remove dupes
 
         for s in keyword_input:


### PR DESCRIPTION
## Issue #712 
### Tasks:
- [x] Implemented POST search in `ProjectAdvancedSearchView`
- [x] Moved similar blocs to SearchMixin
- [x] Removed 'multi-mode' search from standard search
- [x] Updated tests

<hr>

### P. s.:

I am not sure, but maybe it is a good idea (low priority of course) to improve readability of code. imho, but `s`, `kw`, `val` could be `setting`, `kwarg`, `value` and so on. 