### PR TITLE
Add url changing in `assert_response*` methods

### DIFF
--- a/projectroles/tests/test_permissions.py
+++ b/projectroles/tests/test_permissions.py
@@ -123,6 +123,10 @@ class TestPermissionBase(TestPermissionMixin, TestCase):
     NOTE: To use with DRF API views, you need to use APITestCase
     """
 
+    def setUp(self):
+        super().setUp()
+        self.url = None
+
 
 class TestProjectPermissionBase(
     ProjectMixin,
@@ -157,6 +161,7 @@ class TestProjectPermissionBase(
         )
 
     def setUp(self):
+        super().setUp()
         # Init roles
         self.init_roles()
         # Init users

--- a/projectroles/tests/test_permissions.py
+++ b/projectroles/tests/test_permissions.py
@@ -40,11 +40,6 @@ REMOTE_SITE_SECRET = build_secret()
 class TestPermissionMixin:
     """Helper class for permission tests"""
 
-    # Special attribute for dynamic URL changing
-    # for use-cases where the URL depends on the object
-    # that is being changed in cleanup_method.
-    dynamic_url = None
-
     def send_request(self, url, method, req_kwargs):
         req_method = getattr(self.client, method.lower(), None)
         if not req_method:
@@ -86,8 +81,9 @@ class TestPermissionMixin:
             users = [users]
 
         for user in users:
-            if cleanup_method and self.dynamic_url:
-                send_url = self.dynamic_url
+            # Refresh url
+            if cleanup_method and self.url:
+                send_url = self.url
             else:
                 send_url = url
             req_kwargs = req_kwargs if req_kwargs else {}

--- a/projectroles/tests/test_permissions_api.py
+++ b/projectroles/tests/test_permissions_api.py
@@ -28,11 +28,6 @@ NEW_PROJECT_TITLE = 'New Project'
 class SODARAPIPermissionTestMixin(SODARAPIViewTestMixin):
     """Mixin for permission testing with knox auth"""
 
-    # Special attribute for dynamic URL changing
-    # for use-cases where the URL depends on the object
-    # that is being changed in cleanup_method.
-    dynamic_url = None
-
     def assert_response_api(
         self,
         url,
@@ -82,8 +77,8 @@ class SODARAPIPermissionTestMixin(SODARAPIViewTestMixin):
             users = [users]
 
         for user in users:
-            if cleanup_method and self.dynamic_url:
-                send_url = self.dynamic_url
+            if cleanup_method and self.url:
+                send_url = self.url
             else:
                 send_url = url
             r_kwargs = {'format': format}

--- a/projectroles/tests/test_permissions_api.py
+++ b/projectroles/tests/test_permissions_api.py
@@ -28,6 +28,11 @@ NEW_PROJECT_TITLE = 'New Project'
 class SODARAPIPermissionTestMixin(SODARAPIViewTestMixin):
     """Mixin for permission testing with knox auth"""
 
+    # Special attribute for dynamic URL changing
+    # for use-cases where the URL depends on the object
+    # that is being changed in cleanup_method.
+    dynamic_url = None
+
     def assert_response_api(
         self,
         url,
@@ -71,12 +76,16 @@ class SODARAPIPermissionTestMixin(SODARAPIViewTestMixin):
                 raise ValueError('Invalid method "{}"'.format(method))
             if req_kwargs:  # Override request kwargs if set
                 r_kwargs.update(req_kwargs)
-            return req_method(url, **r_kwargs)
+            return req_method(send_url, **r_kwargs)
 
         if not isinstance(users, (list, tuple)):
             users = [users]
 
         for user in users:
+            if cleanup_method and self.dynamic_url:
+                send_url = self.dynamic_url
+            else:
+                send_url = url
             r_kwargs = {'format': format}
             if data:
                 r_kwargs['data'] = data


### PR DESCRIPTION
## Issue: #1234 
### Notes:

The current implementation looks way too user-unfriendly as the cleanup_method has to have self.dynamic_url = url (where url is newly formed url). Besides the self.dynamic_url has to be protected from overwriting.

Bute there are also good points as well:
 - Nothing crashes after changings
 - It is internal function, that is used only in tests (so developers would be able to find the way of implementation the proper cleanup_methods)
 
So here is an example of usage the new dynamic_url (from SODAR):
```
    def _update_request_url(self):
        """Cleanup method"""
        self.irods_request = self.create_request()
        self.url = reverse(
            'samplesheets:api_irods_request_accept',
            kwargs={'irodsdatarequest': self.irods_request.sodar_uuid},
        )  # Update the instance variable

# Test
            irods_request = self.create_request()
            url_accept = reverse(
                'samplesheets:api_irods_request_accept',
                kwargs={'irodsdatarequest': irods_request.sodar_uuid},
            )
            self.assert_response_api(
                url_accept,
                user,
                200,
                method='POST',
                data={'confirm': True},
                cleanup_method=_update_request_url,
            )
```