### PR TITLE
fix: using forks from pypi rather than source URLs in dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,7 +45,7 @@ versioneer==0.23
 ######################
 
 # Django-plugins (with Django v3.0+ support)
--e git+https://github.com/mikkonie/django-plugins.git@42e86e7904e5c09f1da32173862b26843eda5dd8#egg=django-plugins
+django-plugins-bihealth==0.4.0
 
 # Rules for permissions
 rules>=3.3, <3.4
@@ -54,7 +54,7 @@ rules>=3.3, <3.4
 djangorestframework>=3.13.1, <3.14
 
 # Keyed list addon for DRF
--e git+https://github.com/mikkonie/drf-keyed-list.git@b03607b866c5706b0e1ea46a7eeaab6527030734#egg=drf-keyed-list
+drf-keyed-list-bihealth==0.1.1
 
 # Token authentication
 django-rest-knox>=4.2.0, <4.3


### PR DESCRIPTION
We probably need this in the `main` branch as well.

https://pypi.org/project/django-plugins-bihealth/

https://pypi.org/project/drf-keyed-list-bihealth/

We'd appreciate a release of django-sodar-core `v0.11.2`