### PR TITLE
Add transferroles command (#1869)

### DIFF
--- a/docs/source/app_projectroles_usage.rst
+++ b/docs/source/app_projectroles_usage.rst
@@ -435,15 +435,16 @@ transferred to the parent category owner. Example:
 
     $ ./manage.py removeroles --user alice --owner bob
 
-Transfer All Roles from a User to Another
---------------------------
+Transfer Roles Between Users
+----------------------------
 
 The ``transferroles`` management command can be used to transfer roles for all
 projects from a user to another one (and optionally deactivate the old user).
 This is useful in cases where e.g. a user with multiple organizational accounts
 switches to using a different one, or they switch from using an authentication
 system to another. If the new user already had a lower-ranking role in a
-project, the new user is promoted to the higher role.
+project, the new user is promoted to the higher role. The old user can be
+deactivated by passing the `-d` flag.
 
 .. code-block:: console
 

--- a/docs/source/app_projectroles_usage.rst
+++ b/docs/source/app_projectroles_usage.rst
@@ -435,6 +435,20 @@ transferred to the parent category owner. Example:
 
     $ ./manage.py removeroles --user alice --owner bob
 
+Transfer All Roles from a User to Another
+--------------------------
+
+The ``transferroles`` management command can be used to transfer roles for all
+projects from a user to another one (and optionally deactivate the old user).
+This is useful in cases where e.g. a user with multiple organizational accounts
+switches to using a different one, or they switch from using an authentication
+system to another. If the new user already had a lower-ranking role in a
+project, the new user is promoted to the higher role.
+
+.. code-block:: console
+
+    $ ./manage.py transferroles --old-user alice --new-user bob
+
 
 User Status Checking
 --------------------

--- a/projectroles/management/commands/batchupdateroles.py
+++ b/projectroles/management/commands/batchupdateroles.py
@@ -89,9 +89,8 @@ class Command(RoleAssignmentModifyMixin, ProjectInviteMixin, BaseCommand):
         elif (
             role_as
             and role_as.project != project
-            and role_as.role.rank > role.rank
+            and role_as.role.rank < role.rank
         ):
-            # QUESTION: If role.rank is lower, doesn't that mean that we are promoting rather than demoting?
             logger.warning(
                 'Skipping as demoting an inherited role is not permitted'
             )

--- a/projectroles/management/commands/batchupdateroles.py
+++ b/projectroles/management/commands/batchupdateroles.py
@@ -73,7 +73,7 @@ class Command(RoleAssignmentModifyMixin, ProjectInviteMixin, BaseCommand):
         Handle role update for an existing user.
 
         :param project: Project object
-        ;param user: User object
+        :param user: User object
         :param role: Role object
         """
         logger.info(f'Updating role of user {user.username} to {role.name}..')
@@ -91,14 +91,15 @@ class Command(RoleAssignmentModifyMixin, ProjectInviteMixin, BaseCommand):
             and role_as.project != project
             and role_as.role.rank > role.rank
         ):
+            # QUESTION: If role.rank is lower, doesn't that mean that we are promoting rather than demoting?
             logger.warning(
                 'Skipping as demoting an inherited role is not permitted'
             )
             return
         self.modify_assignment(
             data={'user': user, 'role': role},
-            request=self.request,
             project=project,
+            request=self.request,
             instance=role_as,
         )
         self.update_count += 1

--- a/projectroles/management/commands/transferroles.py
+++ b/projectroles/management/commands/transferroles.py
@@ -1,0 +1,218 @@
+"""
+Transferroles management command for transferring all project roles
+to a new user.
+"""
+
+import sys
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from projectroles.management.logging import ManagementCommandLogger
+from projectroles.models import SODAR_CONSTANTS, Project, RoleAssignment
+from projectroles.views import (
+    RoleAssignmentDeleteMixin,
+    RoleAssignmentModifyMixin,
+    RoleAssignmentOwnerTransferMixin,
+)
+
+logger = ManagementCommandLogger(__name__)
+User = get_user_model()
+
+
+# SODAR constants
+PROJECT_ROLE_OWNER = SODAR_CONSTANTS['PROJECT_ROLE_OWNER']
+
+# Local constants
+USER_NOT_FOUND_MSG = 'User not found with username: {}'
+
+
+class Command(
+    RoleAssignmentOwnerTransferMixin,
+    RoleAssignmentModifyMixin,
+    RoleAssignmentDeleteMixin,
+    BaseCommand,
+):
+    help = 'Transfer all project roles to a new user.'
+
+    def _transfer_owner(
+        self,
+        project: Project,
+        new_user: User,
+        role_as: RoleAssignment,
+        p_title: str,
+    ) -> bool:
+        try:
+            with transaction.atomic():
+                self.transfer_owner(
+                    project=project,
+                    new_owner=new_user,
+                    old_owner_as=role_as,
+                    old_owner_role=None,
+                    notify_old=False,
+                    notify_new=False,
+                )
+                logger.info(
+                    f'Transferred ownership in {p_title} to {new_user.username}'
+                )
+                return True
+        except Exception as ex:
+            logger.error(
+                f'Failed to transfer ownership in {p_title} to '
+                f'{new_user.username}: {ex}'
+            )
+            return False
+
+    def _transfer_assignment(
+        self,
+        project: Project,
+        new_user: User,
+        role_as: RoleAssignment,
+        p_title: str,
+    ) -> bool:
+        try:
+            with transaction.atomic():
+                self.delete_assignment(role_as, None, False)
+                self._create_role_or_promote(
+                    project, new_user, role_as, p_title
+                )
+                return True
+        except Exception as ex:
+            logger.error(
+                f'Failed to transfer role "{role_as.role}" in {p_title} to '
+                f'{new_user.username}: {ex}'
+            )
+            return False
+
+    def _create_role_or_promote(
+        self,
+        project: Project,
+        new_user: User,
+        role_as: RoleAssignment,
+        p_title: str,
+    ):
+        new_user_roles = RoleAssignment.objects.filter(
+            user=new_user, project=project
+        )
+        data = {
+            'user': new_user,
+            'role': role_as.role,
+        }
+        if new_user_roles.count() == 0:
+            # Create the new role
+            self.modify_assignment(
+                data=data,
+                project=project,
+                notify=False,
+            )
+            logger.info(
+                f'Created role "{role_as.role}" in {p_title} for '
+                f'{new_user.username}'
+            )
+        else:
+            # Promote user to higher role
+            assert new_user_roles.count() == 1
+            instance = new_user_roles.first()
+            if role_as.role.rank < instance.role.rank:
+                self.modify_assignment(
+                    data=data,
+                    project=project,
+                    instance=instance,
+                    notify=False,
+                )
+                logger.info(
+                    f'Promoted {new_user.username} to role "{role_as.role}" '
+                    f'in {p_title}'
+                )
+            else:
+                logger.info(
+                    f'Skipping "{role_as.role}" role assignment for '
+                    f'{new_user.username} in {p_title}'
+                )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-o',
+            '--old-user',
+            dest='old_user',
+            required=True,
+            help='User name of user whose roles will be removed',
+        )
+        parser.add_argument(
+            '-n',
+            '--new-user',
+            dest='new_user',
+            required=True,
+            help='User name of user who will receive the new roles',
+        )
+        parser.add_argument(
+            '-d',
+            '--deactivate',
+            dest='deactivate',
+            required=False,
+            default=False,
+            action='store_true',
+            help='Deactivate old-user after removing their roles',
+        )
+
+    def handle(self, *args, **options):
+        if options['old_user'] == options['new_user']:
+            logger.error(
+                'Same username given for both old and new user: {}'.format(
+                    options['old_user']
+                )
+            )
+            sys.exit(1)
+
+        try:
+            old_user = User.objects.get(username=options['old_user'])
+        except User.DoesNotExist:
+            logger.error(USER_NOT_FOUND_MSG.format(options['old_user']))
+            sys.exit(1)
+        try:
+            new_user = User.objects.get(username=options['new_user'])
+        except User.DoesNotExist:
+            logger.error(USER_NOT_FOUND_MSG.format(options['new_user']))
+            sys.exit(1)
+        logger.info(
+            'Transferring project roles from user "{}" to user "{}"..'.format(
+                old_user.username,
+                new_user.username,
+            )
+        )
+        old_user_roles = RoleAssignment.objects.filter(user=old_user).order_by(
+            'project__full_title'
+        )
+        if old_user_roles.count() == 0:
+            logger.info(f'No roles found for {old_user.username}')
+            return
+
+        role_count = 0
+        fail_count = 0
+        for role_as in old_user_roles:
+            project = role_as.project
+            p_title = project.get_log_title()
+            # Owner role reassignment
+            if role_as.role.name == PROJECT_ROLE_OWNER:
+                update_ok = self._transfer_owner(
+                    project, new_user, role_as, p_title
+                )
+            else:  # Non-owner role transfer
+                update_ok = self._transfer_assignment(
+                    project, new_user, role_as, p_title
+                )
+            if update_ok is True:
+                role_count += 1
+            else:
+                fail_count += 1
+
+        if options['deactivate']:
+            old_user.is_active = False
+            old_user.save()
+            logger.info(f'User "{old_user.username}" deactivated')
+
+        logger.info(
+            f'Transferred roles from user "{old_user.username}" to user '
+            f'"{new_user.username}" ({role_count} OK, {fail_count} failed)'
+        )

--- a/projectroles/management/commands/transferroles.py
+++ b/projectroles/management/commands/transferroles.py
@@ -193,6 +193,9 @@ class Command(
         for role_as in old_user_roles:
             project = role_as.project
             p_title = project.get_log_title()
+            if project.is_remote():  # Skip remote projects
+                logger.debug(f'Skipping remote project: {p_title}')
+                continue
             # Owner role reassignment
             if role_as.role.name == PROJECT_ROLE_OWNER:
                 update_ok = self._transfer_owner(

--- a/projectroles/management/commands/transferroles.py
+++ b/projectroles/management/commands/transferroles.py
@@ -1,6 +1,6 @@
 """
 Transferroles management command for transferring all project roles
-to a new user.
+to another user.
 """
 
 import sys
@@ -34,7 +34,7 @@ class Command(
     RoleAssignmentDeleteMixin,
     BaseCommand,
 ):
-    help = 'Transfer all project roles to a new user.'
+    help = 'Transfer all project roles to another user.'
 
     def _transfer_owner(
         self,
@@ -60,27 +60,6 @@ class Command(
         except Exception as ex:
             logger.error(
                 f'Failed to transfer ownership in {p_title} to '
-                f'{new_user.username}: {ex}'
-            )
-            return False
-
-    def _transfer_assignment(
-        self,
-        project: Project,
-        new_user: User,
-        role_as: RoleAssignment,
-        p_title: str,
-    ) -> bool:
-        try:
-            with transaction.atomic():
-                self.delete_assignment(role_as, None, False)
-                self._create_role_or_promote(
-                    project, new_user, role_as, p_title
-                )
-                return True
-        except Exception as ex:
-            logger.error(
-                f'Failed to transfer role "{role_as.role}" in {p_title} to '
                 f'{new_user.username}: {ex}'
             )
             return False
@@ -113,12 +92,12 @@ class Command(
         else:
             # Promote user to higher role
             assert new_user_roles.count() == 1
-            instance = new_user_roles.first()
-            if role_as.role.rank < instance.role.rank:
+            new_user_role = new_user_roles.first()
+            if role_as.role.rank < new_user_role.role.rank:
                 self.modify_assignment(
                     data=data,
                     project=project,
-                    instance=instance,
+                    instance=new_user_role,
                     notify=False,
                 )
                 logger.info(
@@ -130,6 +109,27 @@ class Command(
                     f'Skipping "{role_as.role}" role assignment for '
                     f'{new_user.username} in {p_title}'
                 )
+
+    def _transfer_assignment(
+        self,
+        project: Project,
+        new_user: User,
+        role_as: RoleAssignment,
+        p_title: str,
+    ) -> bool:
+        try:
+            with transaction.atomic():
+                self.delete_assignment(role_as, None, False)
+                self._create_role_or_promote(
+                    project, new_user, role_as, p_title
+                )
+                return True
+        except Exception as ex:
+            logger.error(
+                f'Failed to transfer role "{role_as.role}" in {p_title} to '
+                f'{new_user.username}: {ex}'
+            )
+            return False
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/projectroles/serializers.py
+++ b/projectroles/serializers.py
@@ -303,8 +303,8 @@ class RoleAssignmentSerializer(
         self.instance = self.post_save(
             self.modify_assignment(
                 data=self.validated_data,
-                request=self.context['request'],
                 project=self.context['project'],
+                request=self.context['request'],
                 instance=self.instance,
             )
         )

--- a/projectroles/tests/test_commands.py
+++ b/projectroles/tests/test_commands.py
@@ -1506,7 +1506,7 @@ class TestTransferRolesCommand(
     """Tests for transferroles command"""
 
     def setUp(self):
-        self.cmd_name = "transferroles"
+        self.cmd_name = 'transferroles'
         self.init_roles()
         # Init users
         self.user_owner_cat = self.make_user('user_owner_cat')
@@ -1619,7 +1619,7 @@ class TestTransferRolesCommand(
         self.assertEqual(AppAlert.objects.count(), 0)
         self.assertEqual(len(mail.outbox), 0)
 
-    def test_dont_demote_non_owner(self):
+    def test_demote_non_owner(self):
         """Test demotion to lower role (should not work)"""
         self.assertTrue(self.project.has_role(self.user_contributor_cat))
         old_user_role = self.project.local_roles.filter(
@@ -1719,7 +1719,7 @@ class TestTransferRolesCommand(
             2,
         )
 
-    def test_dont_demote_owner(self):
+    def test_demote_owner(self):
         """Test demotion to non-owner (should not work)"""
         self.assertEqual(self.project.get_owner().user, self.user_owner)
         self.assertTrue(self.project.has_role(self.user_contributor))

--- a/projectroles/tests/test_commands.py
+++ b/projectroles/tests/test_commands.py
@@ -1497,6 +1497,309 @@ class TestSyncGroups(TestCase):
         self.assertEqual(group.name, LDAP_DOMAIN.lower())
 
 
+class TestTransferRolesCommand(
+    ProjectMixin,
+    RoleMixin,
+    RoleAssignmentMixin,
+    RemoteSiteMixin,
+    RemoteProjectMixin,
+    TestCase,
+):
+    """Tests for transferroles command"""
+
+    def setUp(self):
+        self.cmd_name = "transferroles"
+        self.init_roles()
+        # Init users
+        self.user_owner_cat = self.make_user('user_owner_cat')
+        self.user_owner = self.make_user('user_owner')
+        self.user_contributor = self.make_user('user_contributor')
+        self.user_contributor_cat = self.make_user('user_contributor_cat')
+        self.user = self.make_user('user')
+        # Init projects
+        self.category = self.make_project(
+            'TestCategory', PROJECT_TYPE_CATEGORY, None
+        )
+        self.cat_owner_as = self.make_assignment(
+            self.category, self.user_owner_cat, self.role_owner
+        )
+        self.cat_contributor_as = self.make_assignment(
+            self.category, self.user_contributor_cat, self.role_contributor
+        )
+        self.project = self.make_project(
+            'TestProject', PROJECT_TYPE_PROJECT, self.category
+        )
+        self.owner_as = self.make_assignment(
+            self.project, self.user_owner, self.role_owner
+        )
+        self.contributor_as = self.make_assignment(
+            self.project, self.user_contributor, self.role_contributor
+        )
+        # user_contributor_cat is also a viewer in the project
+        self.cat_viewer = self.make_assignment(
+            self.project, self.user_contributor_cat, self.role_viewer
+        )
+
+    def test_create_non_owner(self):
+        """Test transfer non-owner roles"""
+        self.assertTrue(self.category.has_role(self.user_contributor_cat))
+        self.assertTrue(self.project.has_role(self.user_contributor_cat))
+        self.assertFalse(self.category.has_role(self.user))
+        self.assertFalse(self.project.has_role(self.user))
+        old_role_count = RoleAssignment.objects.count()
+
+        call_command(
+            self.cmd_name,
+            old_user=self.user_contributor_cat,
+            new_user=self.user,
+        )
+        self.assertFalse(self.category.has_role(self.user_contributor_cat))
+        self.assertFalse(self.project.has_role(self.user_contributor_cat))
+        self.assertTrue(self.category.has_role(self.user))
+        self.assertTrue(self.project.has_role(self.user))
+        self.assertEqual(
+            RoleAssignment.objects.filter(
+                user=self.user_contributor_cat
+            ).count(),
+            0,
+        )
+        self.assertEqual(
+            RoleAssignment.objects.filter(user=self.user).count(), 2
+        )
+
+        # Test that roles are neither created nor destroyed during the transfer
+        self.assertEqual(RoleAssignment.objects.count(), old_role_count)
+
+        # Test that both users are still active
+        self.user.refresh_from_db()
+        self.user_contributor_cat.refresh_from_db()
+        self.assertTrue(self.user.is_active)
+        self.assertTrue(self.user_contributor_cat.is_active)
+
+    def test_promote_non_owner(self):
+        """Test promotion to non-owner role"""
+        self.assertTrue(self.project.has_role(self.user_contributor))
+        old_user_role = self.project.local_roles.filter(
+            user=self.user_contributor
+        ).first()
+        self.assertEqual(old_user_role.role, self.role_contributor)
+
+        self.assertTrue(self.project.has_role(self.user_contributor_cat))
+        new_user_role = self.project.local_roles.filter(
+            user=self.user_contributor_cat
+        ).first()
+        self.assertEqual(new_user_role.role, self.role_viewer)
+        self.assertTrue(old_user_role.role.rank < new_user_role.role.rank)
+
+        # In this test we also ensure timeline events are created,
+        # and app alerts are NOT created, and email is NOT sent
+        self.assertEqual(TimelineEvent.objects.count(), 0)
+        self.assertEqual(AppAlert.objects.count(), 0)
+        self.assertEqual(len(mail.outbox), 0)
+
+        call_command(
+            self.cmd_name,
+            old_user=self.user_contributor,
+            new_user=self.user_contributor_cat,
+        )
+        self.assertFalse(self.project.has_role(self.user_contributor))
+        self.assertEqual(
+            RoleAssignment.objects.filter(user=self.user_contributor).count(), 0
+        )
+        new_user_new_role = self.project.local_roles.filter(
+            user=self.user_contributor_cat
+        ).first()
+        self.assertEqual(new_user_new_role.role, old_user_role.role)
+
+        self.assertEqual(TimelineEvent.objects.count(), 2)
+        self.assertEqual(
+            TimelineEvent.objects.filter(event_name='role_delete').count(), 1
+        )
+        self.assertEqual(
+            TimelineEvent.objects.filter(event_name='role_update').count(), 1
+        )
+        self.assertEqual(AppAlert.objects.count(), 0)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_dont_demote_non_owner(self):
+        """Test demotion to lower role (should not work)"""
+        self.assertTrue(self.project.has_role(self.user_contributor_cat))
+        old_user_role = self.project.local_roles.filter(
+            user=self.user_contributor_cat
+        ).first()
+        self.assertEqual(old_user_role.role, self.role_viewer)
+
+        self.assertTrue(self.project.has_role(self.user_contributor))
+        new_user_role = self.project.local_roles.filter(
+            user=self.user_contributor
+        ).first()
+        self.assertEqual(new_user_role.role, self.role_contributor)
+        self.assertTrue(old_user_role.role.rank > new_user_role.role.rank)
+
+        call_command(
+            self.cmd_name,
+            old_user=self.user_contributor_cat,
+            new_user=self.user_contributor,
+        )
+        self.assertFalse(self.project.has_role(self.user_contributor_cat))
+        self.assertEqual(
+            RoleAssignment.objects.filter(
+                user=self.user_contributor_cat
+            ).count(),
+            0,
+        )
+        new_user_new_role = self.project.local_roles.filter(
+            user=self.user_contributor
+        ).first()
+        self.assertEqual(new_user_new_role.role, new_user_role.role)
+
+        # Besides not being demoted to viewer, user_contributor is also assigned
+        # "contributor" role to the category
+        self.assertEqual(
+            RoleAssignment.objects.filter(user=self.user_contributor).count(), 2
+        )
+        self.assertTrue(self.category.has_role(self.user_contributor))
+
+    def test_create_owner(self):
+        """Test ownership transfer with no existing role for new user"""
+        self.assertEqual(self.project.get_owner().user, self.user_owner)
+        self.assertFalse(self.project.has_role(self.user))
+        self.assertEqual(
+            RoleAssignment.objects.filter(user=self.user).count(), 0
+        )
+
+        call_command(
+            self.cmd_name, old_user=self.user_owner, new_user=self.user
+        )
+        self.assertFalse(self.project.has_role(self.user_owner))
+        self.assertEqual(
+            RoleAssignment.objects.filter(user=self.user_owner).count(), 0
+        )
+        self.assertEqual(self.project.get_owner().user, self.user)
+        self.assertEqual(
+            RoleAssignment.objects.filter(user=self.user).count(), 1
+        )
+
+        # Test timeline event for owner transfer
+        self.assertEqual(TimelineEvent.objects.count(), 1)
+        self.assertEqual(
+            TimelineEvent.objects.filter(
+                event_name='role_owner_transfer'
+            ).count(),
+            1,
+        )
+        self.assertEqual(AppAlert.objects.count(), 0)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_promote_owner(self):
+        """Test ownership transfer with pre-existing role for new user"""
+        self.assertEqual(self.category.get_owner().user, self.user_owner_cat)
+        self.assertTrue(self.category.has_role(self.user_contributor_cat))
+        self.assertEqual(
+            self.category.local_roles.filter(user=self.user_contributor_cat)
+            .first()
+            .role,
+            self.role_contributor,
+        )
+
+        call_command(
+            self.cmd_name,
+            old_user=self.user_owner_cat,
+            new_user=self.user_contributor_cat,
+        )
+        self.assertFalse(self.category.has_role(self.user_owner_cat))
+        self.assertEqual(
+            RoleAssignment.objects.filter(user=self.user_owner_cat).count(), 0
+        )
+        self.assertEqual(
+            self.category.get_owner().user, self.user_contributor_cat
+        )
+        self.assertEqual(
+            RoleAssignment.objects.filter(
+                user=self.user_contributor_cat
+            ).count(),
+            2,
+        )
+
+    def test_dont_demote_owner(self):
+        """Test demotion to non-owner (should not work)"""
+        self.assertEqual(self.project.get_owner().user, self.user_owner)
+        self.assertTrue(self.project.has_role(self.user_contributor))
+        owner_role = self.project.local_roles.filter(
+            user=self.user_owner
+        ).first()
+        contributor_role = self.project.local_roles.filter(
+            user=self.user_contributor
+        ).first()
+        self.assertTrue(owner_role.role.rank < contributor_role.role.rank)
+
+        call_command(
+            self.cmd_name,
+            old_user=self.user_contributor,
+            new_user=self.user_owner,
+        )
+        self.assertEqual(self.project.get_owner().user, self.user_owner)
+        self.assertFalse(self.project.has_role(self.user_contributor))
+
+    def test_transfer_from_nonexistent_user(self):
+        """Test that transfer fails when old_user doesn't exist"""
+        old_roles = RoleAssignment.objects.all()
+        with self.assertRaises(SystemExit):
+            call_command(
+                self.cmd_name, old_user='INVALID-NAME', new_user=self.user
+            )
+        new_roles = RoleAssignment.objects.all()
+        self.assertEqual(list(old_roles), list(new_roles))
+
+    def test_transfer_to_nonexistent_user(self):
+        """Test that transfer fails when new_user doesn't exist"""
+        old_roles = RoleAssignment.objects.all()
+        with self.assertRaises(SystemExit):
+            call_command(
+                self.cmd_name, old_user=self.user_owner, new_user='INVALID-NAME'
+            )
+        new_roles = RoleAssignment.objects.all()
+        self.assertEqual(list(old_roles), list(new_roles))
+
+    def test_transfer_to_self(self):
+        """Test that transfer fails when old_user==new_user"""
+        with self.assertRaises(SystemExit):
+            call_command(
+                self.cmd_name,
+                old_user=self.user_owner,
+                new_user=self.user_owner,
+            )
+
+    def test_deactivate_user(self):
+        """Test ownership transfer with no existing role for new user"""
+        self.assertEqual(self.category.get_owner().user, self.user_owner_cat)
+        self.assertFalse(self.category.has_role(self.user_contributor))
+        self.assertEqual(
+            RoleAssignment.objects.filter(user=self.user_contributor).count(), 1
+        )
+
+        call_command(
+            self.cmd_name,
+            old_user=self.user_owner_cat,
+            new_user=self.user_contributor,
+            deactivate=True,
+        )
+        self.assertFalse(self.category.has_role(self.user_owner_cat))
+        self.assertEqual(
+            RoleAssignment.objects.filter(user=self.user_owner_cat).count(), 0
+        )
+        self.assertEqual(
+            RoleAssignment.objects.filter(user=self.user_contributor).count(), 2
+        )
+        self.assertEqual(self.category.get_owner().user, self.user_contributor)
+
+        # Test that old_user is deactivated (but not new_user)
+        self.user_owner_cat.refresh_from_db()
+        self.assertFalse(self.user_owner_cat.is_active)
+        self.user_contributor.refresh_from_db()
+        self.assertTrue(self.user_contributor.is_active)
+
+
 @override_settings(DEBUG=True)
 class TestCreateDevUsers(TestCase):
     """Tests for createdevusers command"""

--- a/projectroles/tests/test_commands.py
+++ b/projectroles/tests/test_commands.py
@@ -4,7 +4,6 @@ import os
 
 from tempfile import NamedTemporaryFile
 from typing import Union
-from unittest import skip
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -599,7 +598,7 @@ class TestBatchUpdateRoles(
             ).count(),
             0,
         )
-        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(len(mail.outbox), 1)
 
     def test_role_add_inherited_equal(self):
         """Test adding role with inherited role of equal rank (should fail)"""
@@ -627,7 +626,6 @@ class TestBatchUpdateRoles(
         )
         self.assertEqual(len(mail.outbox), 0)
 
-    @skip(reason='need input from Mikko')
     def test_role_add_inherited_lower(self):
         """Test adding role with inherited role of lower rank (should fail)"""
         user_new = self.make_user('user_new')

--- a/projectroles/tests/test_commands.py
+++ b/projectroles/tests/test_commands.py
@@ -4,6 +4,7 @@ import os
 
 from tempfile import NamedTemporaryFile
 from typing import Union
+from unittest import skip
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -626,6 +627,7 @@ class TestBatchUpdateRoles(
         )
         self.assertEqual(len(mail.outbox), 0)
 
+    @skip(reason='need input from Mikko')
     def test_role_add_inherited_lower(self):
         """Test adding role with inherited role of lower rank (should fail)"""
         user_new = self.make_user('user_new')

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -2115,6 +2115,7 @@ class RoleAssignmentModifyMixin(ProjectModifyPluginViewMixin):
         project: Project,
         instance: Optional[RoleAssignment] = None,
         promote: bool = False,
+        notify: bool = True,
     ) -> RoleAssignment:
         """
         Create or update a RoleAssignment. This method should be called either
@@ -2127,6 +2128,7 @@ class RoleAssignmentModifyMixin(ProjectModifyPluginViewMixin):
         :param project: Project object
         :param instance: Existing RoleAssignment object or None
         :param promote: Promoting an inherited user (boolean, default=False)
+        :param notify: Add app alerts and send email if True (default=True)
         :return: Created or updated RoleAssignment object
         """
         app_alerts = plugin_api.get_backend_api('appalerts_backend')
@@ -2172,7 +2174,7 @@ class RoleAssignmentModifyMixin(ProjectModifyPluginViewMixin):
         if tl_event:
             tl_event.set_status('OK')
 
-        if request.user != user:
+        if notify and request.user != user:
             if app_alerts and app_settings.get(
                 APP_NAME, 'notify_alert_role', user=user
             ):
@@ -2829,6 +2831,7 @@ class RoleAssignmentOwnerTransferMixin(
         old_owner_role: Optional[Role] = None,
         request: Optional[HttpRequest] = None,
         notify_old: bool = True,
+        notify_new: bool = True,
     ):
         """
         Transfer project ownership to a new user and assign a new role to the
@@ -2840,6 +2843,7 @@ class RoleAssignmentOwnerTransferMixin(
         :param old_owner_role: Role object for old owner's new role or None
         :param request: HttpRequest object or None
         :param notify_old: Notify old owner (boolean, default=True)
+        :param notify_new: Notify new owner (boolean, default=True)
         """
         app_alerts = plugin_api.get_backend_api('appalerts_backend')
         self.role_owner = Role.objects.get(name=PROJECT_ROLE_OWNER)
@@ -2924,7 +2928,7 @@ class RoleAssignmentOwnerTransferMixin(
                     request,
                 )
         # Notify new owner
-        if not new_inh_owner and issuer != new_owner:
+        if notify_new and not new_inh_owner and issuer != new_owner:
             if app_alerts and app_settings.get(
                 APP_NAME, 'notify_alert_role', user=new_owner
             ):

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -2111,8 +2111,8 @@ class RoleAssignmentModifyMixin(ProjectModifyPluginViewMixin):
     def modify_assignment(
         self,
         data: dict,
-        request: HttpRequest,
         project: Project,
+        request: Optional[HttpRequest] = None,
         instance: Optional[RoleAssignment] = None,
         promote: bool = False,
         notify: bool = True,
@@ -2124,8 +2124,8 @@ class RoleAssignmentModifyMixin(ProjectModifyPluginViewMixin):
         in your plugin.
 
         :param data: Cleaned data from a form or serializer
-        :param request: Request initiating the action
         :param project: Project object
+        :param request: Request initiating the action or None
         :param instance: Existing RoleAssignment object or None
         :param promote: Promoting an inherited user (boolean, default=False)
         :param notify: Add app alerts and send email if True (default=True)
@@ -2149,7 +2149,7 @@ class RoleAssignmentModifyMixin(ProjectModifyPluginViewMixin):
             tl_event = timeline.add_event(
                 project=project,
                 app_name=APP_NAME,
-                user=request.user,
+                user=request.user if request else None,
                 event_name=f'role_{action.lower()}',
                 description=tl_desc,
             )
@@ -2159,7 +2159,7 @@ class RoleAssignmentModifyMixin(ProjectModifyPluginViewMixin):
             role_as = RoleAssignment(project=project, user=user, role=role)
             old_role = None
         else:
-            role_as = RoleAssignment.objects.get(project=project, user=user)
+            role_as = instance
             old_role = role_as.role
             role_as.role = role
         role_as.save()
@@ -2174,7 +2174,7 @@ class RoleAssignmentModifyMixin(ProjectModifyPluginViewMixin):
         if tl_event:
             tl_event.set_status('OK')
 
-        if notify and request.user != user:
+        if notify and request and request.user != user:
             if app_alerts and app_settings.get(
                 APP_NAME, 'notify_alert_role', user=user
             ):
@@ -2240,8 +2240,8 @@ class RoleAssignmentModifyFormMixin(RoleAssignmentModifyMixin, ModelFormMixin):
         try:
             self.object = self.modify_assignment(
                 data=form.cleaned_data,
-                request=self.request,
                 project=project,
+                request=self.request,
                 instance=form.instance if instance else None,
                 promote=True if form.cleaned_data.get('promote') else False,
             )


### PR DESCRIPTION
This PR adds a new management command, `transferroles`, which transfers the roles for all projects from one user to another. The implementation follows the spec in #1869. During this work, a separate problem in the `batchupdateroles` command was discovered (reported in #1874) and fixed as discussed IRL with @mikkonie.

I have also added some documentation, but it can be removed if the command should be internal (I was not sure about that).