### PR TITLE
Validate project/user kwargs in AppSettingsAPI.get()

### DIFF
--- a/projectroles/app_settings.py
+++ b/projectroles/app_settings.py
@@ -468,8 +468,8 @@ class AppSettingAPI:
         :param post_safe: Whether a POST safe value should be returned (bool)
         :param validate: Validate project and user args (bool, default=True)
         :return: Value
-        :raise: ValueError if nothing is found with setting_name, or if neither
-                project nor user are set
+        :raise: KeyError if nothing is found with setting_name
+        :raise: ValueError if neither project nor user are set
         """
         if validate:
             s_def = cls.get_definition(
@@ -599,7 +599,7 @@ class AppSettingAPI:
         :raise: ValueError if validating and value is not accepted for setting
                 type
         :raise: ValueError if neither project nor user are set
-        :raise: ValueError if setting name is not found in plugin specification
+        :raise: KeyError if setting name is not found in plugin specification
         """
         s_def = cls.get_definition(name=setting_name, plugin_name=plugin_name)
         cls._validate_project_and_user(s_def.scope, project, user)
@@ -819,7 +819,7 @@ class AppSettingAPI:
         """
         defs = cls._get_defs(plugin, plugin_name)
         if name not in defs:
-            raise ValueError(
+            raise KeyError(
                 f'App setting not found in plugin '
                 f'"{plugin_name or plugin.name}" with name "{name}"'
             )

--- a/projectroles/app_settings.py
+++ b/projectroles/app_settings.py
@@ -471,7 +471,20 @@ class AppSettingAPI:
         """
         s_def = cls.get_definition(name=setting_name, plugin_name=plugin_name)
         cls._validate_project_and_user(s_def.scope, project, user)
-        if not user or user.is_authenticated:
+        if APP_SETTING_SCOPE_ARGS[s_def.scope]['project'] and not project.pk:
+            # This occurs in ProjectCreateView, which tries to get settings
+            # when the project is not saved in the db yet: django throws a
+            # ValueError: 'Model instances passed to related filters must be
+            # saved.' We could either catch this exception later or prevent it
+            # from happening with this if block.
+            val = cls.get_default(
+                plugin_name,
+                setting_name,
+                project=project,
+                user=user,
+                post_safe=post_safe,
+            )
+        elif not user or user.is_authenticated:
             try:
                 val = AppSetting.objects.get_setting_value(
                     plugin_name, setting_name, project=project, user=user

--- a/projectroles/app_settings.py
+++ b/projectroles/app_settings.py
@@ -455,6 +455,7 @@ class AppSettingAPI:
         project: Optional[Project] = None,
         user: Optional[User] = None,
         post_safe: bool = False,
+        validate: bool = True,
     ) -> Any:
         """
         Return app setting value for a project or a user. If not set, return
@@ -465,26 +466,17 @@ class AppSettingAPI:
         :param project: Project object (optional)
         :param user: User object (optional)
         :param post_safe: Whether a POST safe value should be returned (bool)
+        :param validate: Validate project and user args (bool, default=True)
         :return: Value
         :raise: ValueError if nothing is found with setting_name, or if neither
                 project nor user are set
         """
-        s_def = cls.get_definition(name=setting_name, plugin_name=plugin_name)
-        cls._validate_project_and_user(s_def.scope, project, user)
-        if APP_SETTING_SCOPE_ARGS[s_def.scope]['project'] and not project.pk:
-            # This occurs in ProjectCreateView, which tries to get settings
-            # when the project is not saved in the db yet: django throws a
-            # ValueError: 'Model instances passed to related filters must be
-            # saved.' We could either catch this exception later or prevent it
-            # from happening with this if block.
-            val = cls.get_default(
-                plugin_name,
-                setting_name,
-                project=project,
-                user=user,
-                post_safe=post_safe,
+        if validate:
+            s_def = cls.get_definition(
+                name=setting_name, plugin_name=plugin_name
             )
-        elif not user or user.is_authenticated:
+            cls._validate_project_and_user(s_def.scope, project, user)
+        if not user or user.is_authenticated:
             try:
                 val = AppSetting.objects.get_setting_value(
                     plugin_name, setting_name, project=project, user=user

--- a/projectroles/app_settings.py
+++ b/projectroles/app_settings.py
@@ -419,14 +419,14 @@ class AppSettingAPI:
         :param post_safe: Whether a POST safe value should be returned (bool)
         :return: Setting value
         :raise: ValueError if app plugin is not found
-        :raise: KeyError if nothing is found with setting_name
+        :raise: ValueError if nothing is found with setting_name
         """
         if plugin_name == APP_NAME:
             s_defs = cls.get_projectroles_defs()
         else:
             s_defs = cls._get_defs(plugin_name=plugin_name)
         if setting_name not in s_defs:
-            raise KeyError(
+            raise ValueError(
                 f'Setting "{setting_name}" not found in app plugin '
                 f'"{plugin_name}"'
             )
@@ -468,7 +468,7 @@ class AppSettingAPI:
         :param post_safe: Whether a POST safe value should be returned (bool)
         :param validate: Validate project and user args (bool, default=True)
         :return: Value
-        :raise: KeyError if nothing is found with setting_name
+        :raise: ValueError if nothing is found with setting_name
         :raise: ValueError if neither project nor user are set
         """
         if validate:
@@ -599,7 +599,7 @@ class AppSettingAPI:
         :raise: ValueError if validating and value is not accepted for setting
                 type
         :raise: ValueError if neither project nor user are set
-        :raise: KeyError if setting name is not found in plugin specification
+        :raise: ValueError if setting name is not found in plugin specification
         """
         s_def = cls.get_definition(name=setting_name, plugin_name=plugin_name)
         cls._validate_project_and_user(s_def.scope, project, user)
@@ -819,7 +819,7 @@ class AppSettingAPI:
         """
         defs = cls._get_defs(plugin, plugin_name)
         if name not in defs:
-            raise KeyError(
+            raise ValueError(
                 f'App setting not found in plugin '
                 f'"{plugin_name or plugin.name}" with name "{name}"'
             )

--- a/projectroles/app_settings.py
+++ b/projectroles/app_settings.py
@@ -466,8 +466,11 @@ class AppSettingAPI:
         :param user: User object (optional)
         :param post_safe: Whether a POST safe value should be returned (bool)
         :return: Value
-        :raise: KeyError if nothing is found with setting_name
+        :raise: ValueError if nothing is found with setting_name, or if neither
+                project nor user are set
         """
+        s_def = cls.get_definition(name=setting_name, plugin_name=plugin_name)
+        cls._validate_project_and_user(s_def.scope, project, user)
         if not user or user.is_authenticated:
             try:
                 val = AppSetting.objects.get_setting_value(
@@ -591,7 +594,7 @@ class AppSettingAPI:
         :raise: ValueError if validating and value is not accepted for setting
                 type
         :raise: ValueError if neither project nor user are set
-        :raise: KeyError if setting name is not found in plugin specification
+        :raise: ValueError if setting name is not found in plugin specification
         """
         s_def = cls.get_definition(name=setting_name, plugin_name=plugin_name)
         cls._validate_project_and_user(s_def.scope, project, user)

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -132,7 +132,7 @@ class SODARAppSettingFormMixin:
         scope = s_def.scope
         scope_kw = {}
         if scope == APP_SETTING_SCOPE_PROJECT:
-            scope_kw = {'project': self.instance if self.instance.pk else None}
+            scope_kw = {'project': self.instance}
         elif scope == APP_SETTING_SCOPE_USER:
             scope_kw = {'user': self.user}  # NOTE: Requires self.user
         s_widget_attrs = s_def.widget_attrs

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -206,7 +206,7 @@ class SODARAppSettingFormMixin:
         value = app_settings.get(
             plugin_name=plugin_name,
             setting_name=s_def.name,
-            validate=self.instance.pk is not None,
+            validate=False,
             **scope_kw,
         )
         if s_def.type == APP_SETTING_TYPE_JSON:

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -132,7 +132,7 @@ class SODARAppSettingFormMixin:
         scope = s_def.scope
         scope_kw = {}
         if scope == APP_SETTING_SCOPE_PROJECT:
-            scope_kw = {'project': self.instance}
+            scope_kw = {'project': self.instance if self.instance.pk else None}
         elif scope == APP_SETTING_SCOPE_USER:
             scope_kw = {'user': self.user}  # NOTE: Requires self.user
         s_widget_attrs = s_def.widget_attrs
@@ -206,6 +206,7 @@ class SODARAppSettingFormMixin:
         value = app_settings.get(
             plugin_name=plugin_name,
             setting_name=s_def.name,
+            validate=self.instance.pk is not None,
             **scope_kw,
         )
         if s_def.type == APP_SETTING_TYPE_JSON:

--- a/projectroles/management/commands/cleanappsettings.py
+++ b/projectroles/management/commands/cleanappsettings.py
@@ -95,7 +95,7 @@ class Command(BaseCommand):
                 # Get allowed project types (if unset, default is PROJECT only)
                 if s_def.scope != APP_SETTING_SCOPE_USER:
                     p_types = s_def.project_types
-            except KeyError:
+            except ValueError:
                 logger.info(self._get_log_msg(s, DEF_NOT_FOUND_MSG, check))
                 if not check:
                     s.delete()

--- a/projectroles/management/commands/cleanappsettings.py
+++ b/projectroles/management/commands/cleanappsettings.py
@@ -95,7 +95,7 @@ class Command(BaseCommand):
                 # Get allowed project types (if unset, default is PROJECT only)
                 if s_def.scope != APP_SETTING_SCOPE_USER:
                     p_types = s_def.project_types
-            except ValueError:
+            except KeyError:
                 logger.info(self._get_log_msg(s, DEF_NOT_FOUND_MSG, check))
                 if not check:
                     s.delete()

--- a/projectroles/tests/test_app_settings.py
+++ b/projectroles/tests/test_app_settings.py
@@ -326,7 +326,7 @@ class TestAppSettingAPI(
 
     def test_get_nonexisting(self):
         """Test get() with non-existing setting"""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             app_settings.get(
                 plugin_name=EXAMPLE_APP_NAME,
                 setting_name='NON-EXISTING SETTING',
@@ -352,6 +352,46 @@ class TestAppSettingAPI(
             post_safe=True,
         )
         self.assertEqual(type(val), str)
+
+    def test_get_scope_project_invalid_args(self):
+        """Test get() with scope project and invalid args"""
+        with self.assertRaises(ValueError):
+            app_settings.get(
+                EXAMPLE_APP_NAME,
+                "project_int_setting",
+                project=None,  # No project
+                user=self.user,
+            )
+
+    def test_get_scope_user_invalid_args(self):
+        """Test get() with scope user and invalid args"""
+        with self.assertRaises(ValueError):
+            app_settings.get(
+                EXAMPLE_APP_NAME,
+                "user_str_setting",
+                project=self.project,
+                user=None,  # No user
+            )
+
+    def test_get_scope_project_user_invalid_args(self):
+        """Test get() with scope project_user and invalid args"""
+        with self.assertRaises(ValueError):
+            app_settings.get(
+                EXAMPLE_APP_NAME,
+                "project_user_bool_setting",
+                project=self.project,
+                user=None,  # No user
+            )
+
+    def test_get_scope_site_invalid_args(self):
+        """Test get() with scope site and invalid args"""
+        with self.assertRaises(ValueError):
+            app_settings.get(
+                EXAMPLE_APP_NAME,
+                "site_bool_setting",
+                project=self.project,  # Project is passed when it shouldn't be
+                user=None,
+            )
 
     def test_get_all_by_scope_project(self):
         """Test get_all_by_scope() with PROJECT scope"""

--- a/projectroles/tests/test_app_settings.py
+++ b/projectroles/tests/test_app_settings.py
@@ -326,7 +326,7 @@ class TestAppSettingAPI(
 
     def test_get_nonexisting(self):
         """Test get() with non-existing setting"""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             app_settings.get(
                 plugin_name=EXAMPLE_APP_NAME,
                 setting_name='NON-EXISTING SETTING',
@@ -633,7 +633,7 @@ class TestAppSettingAPI(
 
     def test_set_undefined(self):
         """Test set() with undefined setting (should fail)"""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             app_settings.set(
                 plugin_name=EXAMPLE_APP_NAME,
                 setting_name='new_setting',
@@ -856,7 +856,7 @@ class TestAppSettingAPI(
 
     def test_get_definition_invalid(self):
         """Test get_definition() with innvalid input"""
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             app_settings.get_definition(
                 'non_existing_setting', plugin_name=EXAMPLE_APP_NAME
             )

--- a/projectroles/tests/test_app_settings.py
+++ b/projectroles/tests/test_app_settings.py
@@ -326,7 +326,7 @@ class TestAppSettingAPI(
 
     def test_get_nonexisting(self):
         """Test get() with non-existing setting"""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             app_settings.get(
                 plugin_name=EXAMPLE_APP_NAME,
                 setting_name='NON-EXISTING SETTING',
@@ -633,7 +633,7 @@ class TestAppSettingAPI(
 
     def test_set_undefined(self):
         """Test set() with undefined setting (should fail)"""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             app_settings.set(
                 plugin_name=EXAMPLE_APP_NAME,
                 setting_name='new_setting',
@@ -856,7 +856,7 @@ class TestAppSettingAPI(
 
     def test_get_definition_invalid(self):
         """Test get_definition() with innvalid input"""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             app_settings.get_definition(
                 'non_existing_setting', plugin_name=EXAMPLE_APP_NAME
             )

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -446,7 +446,7 @@ class ProjectContextMixin(
         else:
             context['project'] = self.get_project()
         # Project tagging/starring
-        if 'project' in context and not getattr(
+        if context.get('project') and not getattr(
             settings, 'PROJECTROLES_KIOSK_MODE', False
         ):
             context['project_starred'] = app_settings.get(


### PR DESCRIPTION
This PR aims to fix #1873 by adding validation for `user` and `project` arguments of `AppSettingsAPI.get()`. Thanks @mikkonie for the support with troubleshooting the ensuing problems in `ProjectCreateView`.

The spec calls for raising a `KeyError` when the setting name doesn't exist; however, the `get_definition()` function, which is now called as part of the validation in `get()`, was raising a `ValueError`. I changed the error type to a `KeyError` because I think this was the intended behavior[^1], but please let me know otherwise.

The new behavior is as follows for both `get()` and `set()` :
- Setting name doesn't exist => `KeyError`
- Plugin name is wrong => `ValueError`
- App name is not set => `ValueError`
- Invalid user/project args based on scope => `ValueError`

**Warning**: I added the new commits to the branch `1873-validate-appsettings-get-fix` instead of creating a new one.

[^1]: The docstring of the `set()` function, which also calls `get_definition()`, says that `KeyError` is raised when the setting name doesn't exist, but actually a `ValueError` was raised, before this change. Tests have been updated accordingly.