### PR TITLE
Add user active status to remote sync 

### DIFF
--- a/docs/source/app_projectroles_usage.rst
+++ b/docs/source/app_projectroles_usage.rst
@@ -656,6 +656,10 @@ Alternatively, the following management command can be used:
     users must be manually created by a target site admin in order for their
     data and roles to be synchronized.
 
+.. note::
+
+    Activity status for all users except superusers is synchronized.
+
 Project Detail View Links
 -------------------------
 

--- a/docs/source/major_changes.rst
+++ b/docs/source/major_changes.rst
@@ -39,6 +39,16 @@ These features were deprecated in v1.3 and have been removed in v1.4.
 Base Test Classes and Mixins
     The base test classes and mixins deprecated in v1.3 have been removed.
 
+REST API View Changes
+---------------------
+
+- Projectroles sync API
+    * Current version: ``2.1`` (breaking changes)
+    * Allowed versions: ``1.0``, ``2.0``, ``2.1``
+    * Add synchonization of ``is_active`` field for users
+    * **NOTE:** If called with API version ``1.0`` or ``2.0``, user activity status will not be synced to target sites.
+    * **NOTE:** The activity status for superusers is not synced.
+
 
 v1.3.2 (2026-01-12)
 *******************

--- a/docs/source/major_changes.rst
+++ b/docs/source/major_changes.rst
@@ -43,7 +43,7 @@ REST API View Changes
 ---------------------
 
 - Projectroles sync API
-    * Current version: ``2.1`` (breaking changes)
+    * Current version: ``2.1`` (non-breaking changes)
     * Allowed versions: ``1.0``, ``2.0``, ``2.1``
     * Add synchonization of ``is_active`` field for users
     * **NOTE:** If called with API version ``1.0`` or ``2.0``, user activity status will not be synced to target sites.

--- a/projectroles/remote_projects.py
+++ b/projectroles/remote_projects.py
@@ -66,6 +66,7 @@ APP_SETTING_TYPE_STRING = SODAR_CONSTANTS['APP_SETTING_TYPE_STRING']
 APP_NAME = 'projectroles'
 NO_LOCAL_USERS_MSG = 'Local users not allowed'
 VERSION_2_0 = parse_version('2.0')
+VERSION_2_1 = parse_version('2.1')
 
 
 class RemoteProjectAPI:
@@ -91,7 +92,11 @@ class RemoteProjectAPI:
 
     @classmethod
     def _add_parent_categories(
-        cls, sync_data: dict, category: Project, project_level: str
+        cls,
+        sync_data: dict,
+        category: Project,
+        project_level: str,
+        req_version: str,
     ) -> dict:
         """
         Add parent categories of a project to source site sync data.
@@ -103,7 +108,7 @@ class RemoteProjectAPI:
         """
         if category.parent:
             sync_data = cls._add_parent_categories(
-                sync_data, category.parent, project_level
+                sync_data, category.parent, project_level, req_version
             )
         # Add if not added yet OR if a READ_ROLES project is encountered
         if str(category.sodar_uuid) not in sync_data['projects'].keys() or (
@@ -128,7 +133,9 @@ class RemoteProjectAPI:
                         'user': role_as.user.username,
                         'role': role_as.role.name,
                     }
-                    sync_data = cls._add_user(sync_data, role_as.user)
+                    sync_data = cls._add_user(
+                        sync_data, role_as.user, req_version
+                    )
             else:
                 cat_data['level'] = REMOTE_LEVEL_READ_INFO
             sync_data['projects'][str(category.sodar_uuid)] = cat_data
@@ -154,7 +161,9 @@ class RemoteProjectAPI:
         return sync_data
 
     @classmethod
-    def _add_user(cls, sync_data: dict, user: SODARUser) -> dict:
+    def _add_user(
+        cls, sync_data: dict, user: SODARUser, req_version: str
+    ) -> dict:
         """
         Add user to source site sync data.
 
@@ -178,6 +187,12 @@ class RemoteProjectAPI:
                 'groups': [g.name for g in user.groups.all()],
                 'sodar_uuid': str(user.sodar_uuid),
             }
+            if parse_version(req_version) >= VERSION_2_1:
+                sync_data['users'][str(user.sodar_uuid)].update(
+                    {
+                        'is_active': user.is_active,
+                    }
+                )
         return sync_data
 
     @classmethod
@@ -345,7 +360,7 @@ class RemoteProjectAPI:
                 # Add parent categories and inherited roles
                 if project.parent:
                     sync_data = self._add_parent_categories(
-                        sync_data, project.parent, rp.level
+                        sync_data, project.parent, rp.level, req_version
                     )
                     project_data['parent_uuid'] = str(project.parent.sodar_uuid)
 
@@ -375,14 +390,16 @@ class RemoteProjectAPI:
                             'user': role_as.user.username,
                             'role': role_as.role.name,
                         }
-                        sync_data = self._add_user(sync_data, role_as.user)
+                        sync_data = self._add_user(
+                            sync_data, role_as.user, req_version
+                        )
             sync_data['projects'][str(rp.project_uuid)] = project_data
 
         # Sync USER scope settings
         for a in AppSetting.objects.filter(project=None).exclude(user=None):
             try:
                 # Add user if they lack roles in remote projects (see #1593)
-                self._add_user(sync_data, a.user)
+                self._add_user(sync_data, a.user, req_version)
                 sync_data = self._add_app_setting(sync_data, a, all_defs)
             except Exception as ex:
                 logger.error(self._get_app_setting_error(a, ex))
@@ -482,11 +499,39 @@ class RemoteProjectAPI:
             return self._check_local_categories(c_data['parent_uuid'])
         return False
 
+    def _sync_user_add_emails(self, user: User, add_emails: list[str]):
+        # Sync additional emails
+        deleted_emails = SODARUserAdditionalEmail.objects.filter(
+            user=user
+        ).exclude(email__in=add_emails)
+        email_update = False
+        for e in deleted_emails:
+            e.delete()
+            logger.info(
+                f'Deleted user {user.username} additional email "{e.email}"'
+            )
+            email_update = True
+        for e in add_emails:
+            if SODARUserAdditionalEmail.objects.filter(
+                user=user, email=e
+            ).exists():
+                continue
+            email_obj = SODARUserAdditionalEmail.objects.create(
+                user=user, email=e, verified=True
+            )
+            logger.info(
+                f'Created user {user.username} additional email '
+                f'"{email_obj.email}"'
+            )
+            email_update = True
+        return email_update
+
     def _sync_user(self, uuid: str, user_data: dict):
         """
         Synchronize user on target site. For local users, will only update an
         existing user object. Local users must be manually created. If local
-        users are not allowed, data is not synchronized.
+        users are not allowed, data is not synchronized. Active status is
+        explicitly synchronized.
 
         :param uuid: User UUID (string)
         :param user_data: User sync data (dict)
@@ -513,6 +558,10 @@ class RemoteProjectAPI:
                     and str(getattr(user, k)) != str(v)
                 ):
                     updated_fields.append(k)
+            # Don't synchronize active status for superusers to avoid unwanted
+            # lockouts for admins
+            if user.is_superuser and 'is_active' in updated_fields:
+                updated_fields.remove('is_active')
 
             if updated_fields:
                 user = self._update_obj(user, user_data, updated_fields)
@@ -569,30 +618,7 @@ class RemoteProjectAPI:
                     f'"{g}"'
                 )
 
-        # Sync additional emails
-        deleted_emails = SODARUserAdditionalEmail.objects.filter(
-            user=user
-        ).exclude(email__in=add_emails)
-        email_update = False
-        for e in deleted_emails:
-            e.delete()
-            logger.info(
-                f'Deleted user {user.username} additional email "{e.email}"'
-            )
-            email_update = True
-        for e in add_emails:
-            if SODARUserAdditionalEmail.objects.filter(
-                user=user, email=e
-            ).exists():
-                continue
-            email_obj = SODARUserAdditionalEmail.objects.create(
-                user=user, email=e, verified=True
-            )
-            logger.info(
-                f'Created user {user.username} additional email '
-                f'"{email_obj.email}"'
-            )
-            email_update = True
+        email_update = self._sync_user_add_emails(user, add_emails)
         # HACK: Re-add additional emails
         user_data['additional_emails'] = add_emails
         # Set user to updated if additional emails were changed

--- a/projectroles/tests/test_remote_project_api.py
+++ b/projectroles/tests/test_remote_project_api.py
@@ -77,6 +77,7 @@ SOURCE_USER_FIRST_NAME = SOURCE_USER_NAME.split(' ')[0]
 SOURCE_USER_LAST_NAME = SOURCE_USER_NAME.split(' ')[1]
 SOURCE_USER_EMAIL = SOURCE_USER_USERNAME.split('@')[0] + '@example.com'
 SOURCE_USER_UUID = str(uuid.uuid4())
+SOURCE_USER_IS_ACTIVE = True
 
 SOURCE_USER2_DOMAIN = SOURCE_USER_DOMAIN
 SOURCE_USER2_USERNAME = 'source_user2@' + SOURCE_USER_DOMAIN
@@ -86,6 +87,7 @@ SOURCE_USER2_FIRST_NAME = SOURCE_USER2_NAME.split(' ')[0]
 SOURCE_USER2_LAST_NAME = SOURCE_USER2_NAME.split(' ')[1]
 SOURCE_USER2_EMAIL = SOURCE_USER2_USERNAME.split('@')[0] + '@example.com'
 SOURCE_USER2_UUID = str(uuid.uuid4())
+SOURCE_USER2_IS_ACTIVE = True
 
 SOURCE_USER3_DOMAIN = SOURCE_USER_DOMAIN
 SOURCE_USER3_USERNAME = 'source_user3@' + SOURCE_USER_DOMAIN
@@ -95,6 +97,7 @@ SOURCE_USER3_FIRST_NAME = SOURCE_USER3_NAME.split(' ')[0]
 SOURCE_USER3_LAST_NAME = SOURCE_USER3_NAME.split(' ')[1]
 SOURCE_USER3_EMAIL = SOURCE_USER3_USERNAME.split('@')[0] + '@example.com'
 SOURCE_USER3_UUID = str(uuid.uuid4())
+SOURCE_USER3_IS_ACTIVE = False
 
 SOURCE_USER4_DOMAIN = SOURCE_USER_DOMAIN
 SOURCE_USER4_USERNAME = 'source_user4@' + SOURCE_USER_DOMAIN
@@ -104,6 +107,7 @@ SOURCE_USER4_FIRST_NAME = SOURCE_USER4_NAME.split(' ')[0]
 SOURCE_USER4_LAST_NAME = SOURCE_USER4_NAME.split(' ')[1]
 SOURCE_USER4_EMAIL = SOURCE_USER4_USERNAME.split('@')[0] + '@example.com'
 SOURCE_USER4_UUID = str(uuid.uuid4())
+SOURCE_USER4_IS_ACTIVE = True
 
 SOURCE_CATEGORY_UUID = str(uuid.uuid4())
 SOURCE_CATEGORY_TITLE = 'TestCategory'
@@ -360,6 +364,19 @@ class TestGetSourceData(
             site=self.peer_site,
             level=REMOTE_LEVEL_READ_ROLES,
         )
+        # Add an inactive user to test activity sync
+        user_inactive = self.make_sodar_user(
+            username='user_inactive@' + SOURCE_USER_DOMAIN,
+            name='Inactive User',
+            first_name='Inactive',
+            last_name='User',
+            email='user_inactive@example.com',
+        )
+        user_inactive.is_active = False
+        user_inactive.save()
+        contrib_as = self.make_assignment(
+            self.project, user_inactive, self.role_contributor
+        )
         sync_data = self.remote_api.get_source_data(**self.get_kw)
         expected = {
             'users': {
@@ -371,8 +388,20 @@ class TestGetSourceData(
                     'email': self.user_source.email,
                     'additional_emails': [],
                     'groups': [SOURCE_USER_GROUP],
+                    'is_active': self.user_source.is_active,
                     'sodar_uuid': str(self.user_source.sodar_uuid),
-                }
+                },
+                str(user_inactive.sodar_uuid): {
+                    'username': user_inactive.username,
+                    'name': user_inactive.name,
+                    'first_name': user_inactive.first_name,
+                    'last_name': user_inactive.last_name,
+                    'email': user_inactive.email,
+                    'additional_emails': [],
+                    'groups': [SOURCE_USER_GROUP],
+                    'is_active': False,
+                    'sodar_uuid': str(user_inactive.sodar_uuid),
+                },
             },
             'projects': {
                 str(self.category.sodar_uuid): {
@@ -400,7 +429,11 @@ class TestGetSourceData(
                         str(self.project_owner_as.sodar_uuid): {
                             'user': self.user_source.username,
                             'role': self.role_owner.name,
-                        }
+                        },
+                        str(contrib_as.sodar_uuid): {
+                            'user': user_inactive.username,
+                            'role': self.role_contributor.name,
+                        },
                     },
                     'remote_sites': [str(self.peer_site.sodar_uuid)],
                 },
@@ -416,6 +449,21 @@ class TestGetSourceData(
             'app_settings': {},
         }
         self.assertEqual(sync_data, expected)
+
+    def test_get_read_roles_v2_0(self):
+        """Test get_source_data() with user roles and API v2.0"""
+        self.make_remote_project(
+            project_uuid=self.project.sodar_uuid,
+            site=self.target_site,
+            level=REMOTE_LEVEL_READ_ROLES,
+        )
+        self.get_kw['req_version'] = '2.0'
+        sync_data = self.remote_api.get_source_data(**self.get_kw)
+        # Active status should not be present
+        self.assertNotIn(
+            'is_active',
+            sync_data['users'][str(self.user_source.sodar_uuid)].keys(),
+        )
 
     def test_get_read_roles_inherited(self):
         """Test get_source_data() with READ_ROLES and inherited contributor"""
@@ -743,6 +791,7 @@ class TestGetSourceData(
                     'email': self.user_source.email,
                     'additional_emails': [],
                     'groups': [SOURCE_USER_GROUP],
+                    'is_active': self.user_source.is_active,
                     'sodar_uuid': str(self.user_source.sodar_uuid),
                 }
             },
@@ -843,6 +892,7 @@ class SyncRemoteDataTestBase(
         self.admin_user = self.make_user(settings.PROJECTROLES_DEFAULT_ADMIN)
         self.admin_user.is_staff = True
         self.admin_user.is_superuser = True
+        self.admin_user.save()
         self.maxDiff = None
         # Init source site
         self.source_site = self.make_site(
@@ -866,6 +916,7 @@ class SyncRemoteDataTestBase(
                     'email': SOURCE_USER_EMAIL,
                     'additional_emails': [],
                     'groups': [SOURCE_USER_GROUP],
+                    'is_active': SOURCE_USER_IS_ACTIVE,
                 },
             },
             'projects': {
@@ -960,6 +1011,7 @@ class TestSyncRemoteDataCreate(SyncRemoteDataTestBase):
                     'email': SOURCE_USER2_EMAIL,
                     'additional_emails': [],
                     'groups': [SOURCE_USER2_GROUP],
+                    'is_active': SOURCE_USER2_IS_ACTIVE,
                 },
                 SOURCE_USER3_UUID: {
                     'sodar_uuid': SOURCE_USER3_UUID,
@@ -970,6 +1022,7 @@ class TestSyncRemoteDataCreate(SyncRemoteDataTestBase):
                     'email': SOURCE_USER3_EMAIL,
                     'additional_emails': [],
                     'groups': [SOURCE_USER3_GROUP],
+                    'is_active': SOURCE_USER3_IS_ACTIVE,
                 },
                 SOURCE_USER4_UUID: {
                     'sodar_uuid': SOURCE_USER4_UUID,
@@ -980,6 +1033,7 @@ class TestSyncRemoteDataCreate(SyncRemoteDataTestBase):
                     'email': SOURCE_USER4_EMAIL,
                     'additional_emails': [],
                     'groups': [SOURCE_USER4_GROUP],
+                    'is_active': SOURCE_USER4_IS_ACTIVE,
                 },
             }
         )
@@ -1086,6 +1140,10 @@ class TestSyncRemoteDataCreate(SyncRemoteDataTestBase):
         new_user2 = User.objects.get(username=SOURCE_USER2_USERNAME)
         new_user3 = User.objects.get(username=SOURCE_USER3_USERNAME)
         new_user4 = User.objects.get(username=SOURCE_USER4_USERNAME)
+        self.assertTrue(new_user.is_active)
+        self.assertTrue(new_user2.is_active)
+        self.assertFalse(new_user3.is_active)
+        self.assertTrue(new_user4.is_active)
         category_obj = Project.objects.get(sodar_uuid=SOURCE_CATEGORY_UUID)
         c_owner_obj = RoleAssignment.objects.get(
             sodar_uuid=SOURCE_CATEGORY_ROLE_UUID
@@ -2045,6 +2103,32 @@ class TestSyncRemoteDataUpdate(
             'sodar_uuid': p_contrib_obj.sodar_uuid,
         }
         self.assertEqual(model_to_dict(p_contrib_obj), expected)
+
+    def test_update_superuser(self):
+        """Test that active status is not changed during sync for superusers"""
+        remote_data = deepcopy(self.remote_data)
+        remote_data['users'][self.admin_user.sodar_uuid] = {
+            'sodar_uuid': self.admin_user.sodar_uuid,
+            'username': self.admin_user.username,
+            'name': 'Bob User',
+            'first_name': 'Bob',
+            'last_name': 'User',
+            'email': 'bob@sodar.org',
+            'additional_emails': [],
+            'groups': [SOURCE_USER_GROUP],
+            'is_active': False,
+        }
+        remote_data['projects'][SOURCE_PROJECT_UUID]['roles'][
+            self.new_role_uuid
+        ] = {
+            'user': self.admin_user.username,
+            'role': PROJECT_ROLE_CONTRIBUTOR,
+        }
+        self.remote_api.sync_remote_data(self.source_site, remote_data)
+        admin_user = User.objects.get(username=self.admin_user.username)
+        self.assertEqual(admin_user.name, 'Bob User')
+        self.assertTrue(admin_user.is_superuser)
+        self.assertTrue(admin_user.is_active)
 
     def test_update_assert_remote_objs(self):
         """Test sync for update and assert remote site and project"""

--- a/projectroles/tests/test_remote_project_api.py
+++ b/projectroles/tests/test_remote_project_api.py
@@ -77,7 +77,6 @@ SOURCE_USER_FIRST_NAME = SOURCE_USER_NAME.split(' ')[0]
 SOURCE_USER_LAST_NAME = SOURCE_USER_NAME.split(' ')[1]
 SOURCE_USER_EMAIL = SOURCE_USER_USERNAME.split('@')[0] + '@example.com'
 SOURCE_USER_UUID = str(uuid.uuid4())
-SOURCE_USER_IS_ACTIVE = True
 
 SOURCE_USER2_DOMAIN = SOURCE_USER_DOMAIN
 SOURCE_USER2_USERNAME = 'source_user2@' + SOURCE_USER_DOMAIN
@@ -87,7 +86,6 @@ SOURCE_USER2_FIRST_NAME = SOURCE_USER2_NAME.split(' ')[0]
 SOURCE_USER2_LAST_NAME = SOURCE_USER2_NAME.split(' ')[1]
 SOURCE_USER2_EMAIL = SOURCE_USER2_USERNAME.split('@')[0] + '@example.com'
 SOURCE_USER2_UUID = str(uuid.uuid4())
-SOURCE_USER2_IS_ACTIVE = True
 
 SOURCE_USER3_DOMAIN = SOURCE_USER_DOMAIN
 SOURCE_USER3_USERNAME = 'source_user3@' + SOURCE_USER_DOMAIN
@@ -97,7 +95,6 @@ SOURCE_USER3_FIRST_NAME = SOURCE_USER3_NAME.split(' ')[0]
 SOURCE_USER3_LAST_NAME = SOURCE_USER3_NAME.split(' ')[1]
 SOURCE_USER3_EMAIL = SOURCE_USER3_USERNAME.split('@')[0] + '@example.com'
 SOURCE_USER3_UUID = str(uuid.uuid4())
-SOURCE_USER3_IS_ACTIVE = False
 
 SOURCE_USER4_DOMAIN = SOURCE_USER_DOMAIN
 SOURCE_USER4_USERNAME = 'source_user4@' + SOURCE_USER_DOMAIN
@@ -107,7 +104,6 @@ SOURCE_USER4_FIRST_NAME = SOURCE_USER4_NAME.split(' ')[0]
 SOURCE_USER4_LAST_NAME = SOURCE_USER4_NAME.split(' ')[1]
 SOURCE_USER4_EMAIL = SOURCE_USER4_USERNAME.split('@')[0] + '@example.com'
 SOURCE_USER4_UUID = str(uuid.uuid4())
-SOURCE_USER4_IS_ACTIVE = True
 
 SOURCE_CATEGORY_UUID = str(uuid.uuid4())
 SOURCE_CATEGORY_TITLE = 'TestCategory'
@@ -893,7 +889,6 @@ class SyncRemoteDataTestBase(
         self.admin_user.is_staff = True
         self.admin_user.is_superuser = True
         self.admin_user.save()
-        self.maxDiff = None
         # Init source site
         self.source_site = self.make_site(
             name=SOURCE_SITE_NAME,
@@ -916,7 +911,7 @@ class SyncRemoteDataTestBase(
                     'email': SOURCE_USER_EMAIL,
                     'additional_emails': [],
                     'groups': [SOURCE_USER_GROUP],
-                    'is_active': SOURCE_USER_IS_ACTIVE,
+                    'is_active': True,
                 },
             },
             'projects': {
@@ -1011,7 +1006,7 @@ class TestSyncRemoteDataCreate(SyncRemoteDataTestBase):
                     'email': SOURCE_USER2_EMAIL,
                     'additional_emails': [],
                     'groups': [SOURCE_USER2_GROUP],
-                    'is_active': SOURCE_USER2_IS_ACTIVE,
+                    'is_active': True,
                 },
                 SOURCE_USER3_UUID: {
                     'sodar_uuid': SOURCE_USER3_UUID,
@@ -1022,7 +1017,7 @@ class TestSyncRemoteDataCreate(SyncRemoteDataTestBase):
                     'email': SOURCE_USER3_EMAIL,
                     'additional_emails': [],
                     'groups': [SOURCE_USER3_GROUP],
-                    'is_active': SOURCE_USER3_IS_ACTIVE,
+                    'is_active': False,
                 },
                 SOURCE_USER4_UUID: {
                     'sodar_uuid': SOURCE_USER4_UUID,
@@ -1033,7 +1028,7 @@ class TestSyncRemoteDataCreate(SyncRemoteDataTestBase):
                     'email': SOURCE_USER4_EMAIL,
                     'additional_emails': [],
                     'groups': [SOURCE_USER4_GROUP],
-                    'is_active': SOURCE_USER4_IS_ACTIVE,
+                    'is_active': True,
                 },
             }
         )

--- a/projectroles/views_api.py
+++ b/projectroles/views_api.py
@@ -106,8 +106,8 @@ PROJECTROLES_API_ALLOWED_VERSIONS = ['1.0', '1.1', '2.0']
 SYNC_API_MEDIA_TYPE = (
     'application/vnd.bihealth.sodar-core.projectroles.sync+json'
 )
-SYNC_API_DEFAULT_VERSION = '2.0'
-SYNC_API_ALLOWED_VERSIONS = ['1.0', '2.0']
+SYNC_API_DEFAULT_VERSION = '2.1'
+SYNC_API_ALLOWED_VERSIONS = ['1.0', '2.0', '2.1']
 
 # Local constants
 APP_NAME = 'projectroles'


### PR DESCRIPTION
This PR attempts to fix #1882 by following the spec described therein.

There are two changes:
- The `is_active` key is removed from `updated_fields` instead of from `user_data`
- The function `_sync_user()` was split in two

The reason for the first is that I've seen that something similar is done for `additional_emails`, where the field is removed from the dictionary and then added at the end. I wasn't sure whether this is needed also for `is_active`, but in order to avoid having to re-add that field at the end, I opted to remove it from `updated_fields`.

The reason for splitting `_sync_user()` was that otherwise the CI would have failed with an error from flake8 about the cyclomatic complexity being too high (19).

The tests are passing but I haven't played with the feature interactively yet, so the PR is marked as draft for the time being.