### PR TITLE
Fix type hint and docstring for keywords argument in ProjectAppPlugin.search()

### DIFF
--- a/docs/source/dev_project_app.rst
+++ b/docs/source/dev_project_app.rst
@@ -637,7 +637,7 @@ See the signature of ``search()`` in
     - You can specify supported types in the plugin's ``search_types`` list.
     - Examples: ``file``, ``sample``..
 ``keywords``
-    - Special search keywords, e.g. "exact".
+    - Special search keywords as key/value pairs.
     - **NOTE:** Currently not implemented.
 
 .. note::

--- a/filesfolders/plugins.py
+++ b/filesfolders/plugins.py
@@ -162,7 +162,7 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
         search_terms: list[str],
         user: User,
         search_type: Optional[str] = None,
-        keywords: Optional[list[str]] = None,
+        keywords: Optional[dict] = None,
     ) -> list[PluginSearchResult]:
         """
         Return app items based on one or more search terms, user, optional type
@@ -172,7 +172,7 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
                              (list of strings)
         :param user: User object for user initiating the search
         :param search_type: String
-        :param keywords: List (optional)
+        :param keywords: Dictionary of key/value pairs (optional)
         :return: List of PluginSearchResult objects
         """
         items = []

--- a/projectroles/plugins.py
+++ b/projectroles/plugins.py
@@ -429,7 +429,7 @@ class ProjectAppPluginPoint(PluginPoint):
         search_terms: list[str],
         user: User,
         search_type: Optional[str] = None,
-        keywords: Optional[list[str]] = None,
+        keywords: Optional[dict] = None,
     ) -> list['PluginSearchResult']:
         """
         Return app items based on one or more search terms, user, optional type
@@ -439,7 +439,7 @@ class ProjectAppPluginPoint(PluginPoint):
                              (list of strings)
         :param user: User object for user initiating the search
         :param search_type: String
-        :param keywords: List (optional)
+        :param keywords: Dictionary of key/value pairs (optional)
         :return: List of PluginSearchResult objects
         """
         # TODO: If implemented, also implement display of results in the app's

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -731,14 +731,14 @@ class ProjectSearchMixin:
         user: User,
         search_terms: list[str],
         search_type: Optional[str],
-        search_keywords: Optional[list[str]],
+        search_keywords: Optional[dict],
     ) -> list:
         """
         Return app plugin search results.
 
         :param search_terms: Search terms (list of strings)
         :param search_type: Optional type keyword for search (string or None)
-        :param search_keywords: Optional keywords (list of strings or None)
+        :param search_keywords: Optional keywords (dictionary or None)
         :return: List
         """
         plugins = plugin_api.get_active_plugins(plugin_type='project_app')

--- a/timeline/plugins.py
+++ b/timeline/plugins.py
@@ -114,7 +114,7 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
         search_terms: list[str],
         user: User,
         search_type: Optional[str] = None,
-        keywords: Optional[list[str]] = None,
+        keywords: Optional[dict] = None,
     ) -> list[PluginSearchResult]:
         """
         Return app items based on one or more search terms, user, optional type
@@ -124,7 +124,7 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
                              (list of strings)
         :param user: User object for user initiating the search
         :param search_type: String
-        :param keywords: List (optional)
+        :param keywords: Dictionary of key/value pairs (optional)
         :return: List of PluginSearchResult objects
         """
         items = []


### PR DESCRIPTION
This PR attempts to fix #1894. I have also taken the liberty to updat the type hint and docstring in `ProjectSearchMixin._get_app_results()`. The example in the docs was updated to reflect the key/value pairs nature of `keywords`, but I think more changes to the docs will be done for #1191 soon.