### PR TITLE
Add title support for project keyword in search

### DIFF
--- a/docs/source/app_projectroles_usage.rst
+++ b/docs/source/app_projectroles_usage.rst
@@ -688,14 +688,21 @@ At this time, two keywords have been implemented:
     Used to limit the search to a certain data type as specified in app
     plugins.
 ``project``
-    Used to restrict the search to the specified project UUID and its
-    children.
+    Used to restrict the search to the given project (specified either by
+    UUID or by title) and its children.
 
 Thus, for example, if you want to search for folders containing the term
 ``diabetes`` under category ``44407b43-85f1-48a9-917c-0df21d9af347``, you could
 write::
 
     diabetes type:folder project:44407b43-85f1-48a9-917c-0df21d9af347
+
+Or, if you want to search for entities related to ``Covid-19`` within a category
+titled ``Infectious diseases``, you can do it like so (note that if the search
+term or the project title contain spaces, they need to be enclosed between
+quotes)::
+
+    covid-19 project:"infectious diseases"
 
 Left to the basic search form is a link to the *Advanced Search* page, where you
 can currently search for items using multiple search terms combined with the OR

--- a/docs/source/dev_project_app.rst
+++ b/docs/source/dev_project_app.rst
@@ -631,6 +631,9 @@ See the signature of ``search()`` in
       via the Advanced Search view.
 ``user``
     - User object for user initiating search.
+``projects``
+    - ``QuerySet`` of Project objects within which the search should be
+      restricted.
 ``search_type``
     - The type of object to search for (string, optional).
     - Used to restrict search to specific types of objects.
@@ -638,8 +641,11 @@ See the signature of ``search()`` in
     - Examples: ``file``, ``sample``..
 ``keywords``
     - Special search keywords as a dictionary of ``key:value`` pairs.
-    - Currently the only supported keyword is ``project:uuid``, which is used
-      to limit the search to a specific project or category.
+    - Currently the only supported keyword is ``project``, which is used to
+      limit the search to a specific project or category. The full list of
+      projects is pre-fetched for efficiency and passed in the ``projects``
+      argument, but apps can optionally also make use of the original
+      user-provided UUID or title.
 
 .. note::
 

--- a/docs/source/major_changes.rst
+++ b/docs/source/major_changes.rst
@@ -45,11 +45,11 @@ The signature of the ``search()`` function implemented by plugins has changed:
 it now takes an extra positional argument, ``projects``, which contains a
 ``QuerySet`` of projects within which the search should be restricted. All
 SODAR Core apps are expected to honor this filtering criterion. Furthermore,
-the ``keywords`` dictionary (passed to ``search()`` as a kwarg) can contain
-a ``project:uuid`` key-value pair which identifies the user-provided project
-or category where the search is restricted. The projects are pre-fetched for
-efficiency and passed to ``search()`` through the ``projects`` argument, but
-apps can optionally also make use of the original UUID.
+the ``keywords`` dictionary (passed to ``search()`` as a kwarg) can contain a
+``project:<uuid or title>`` key-value pair which identifies the user-provided
+project or category where the search is restricted. The projects are pre-fetched
+for efficiency and passed to ``search()`` through the ``projects`` argument, but
+apps can optionally also make use of the original UUID or title.
 
 Previously Deprecated Features Removed
 --------------------------------------

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -442,6 +442,27 @@ class TestProjectSearchResultsView(
             len([p for p in self.plugins if p.search_enable]),
         )
 
+    def test_get_quoted(self):
+        """Test ProjectSearchResultsView GET with quoted search term"""
+        with self.login(self.user):
+            response = self.client.get(
+                reverse('projectroles:search')
+                + '?'
+                + urlencode({'s': '"test quoted"'})
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['search_terms'], ['test quoted'])
+        self.assertEqual(response.context['search_keywords'], {})
+        self.assertEqual(response.context['search_type'], None)
+        self.assertQuerySetEqual(
+            response.context['search_projects'], Project.objects.all()
+        )
+        self.assertEqual(response.context['search_input'], '"test quoted"')
+        self.assertEqual(
+            len(response.context['app_results']),
+            len([p for p in self.plugins if p.search_enable]),
+        )
+
     def test_get_search_type(self):
         """Test GET with search type"""
         with self.login(self.user):
@@ -487,6 +508,10 @@ class TestProjectSearchResultsView(
             {'project': str(self.project.sodar_uuid)},
         )
         self.assertEqual(response.context['search_type'], None)
+        self.assertQuerySetEqual(
+            response.context['search_projects'],
+            Project.objects.filter(sodar_uuid=self.project.sodar_uuid),
+        )
         self.assertEqual(
             response.context['search_input'],
             f'test project:{self.project.sodar_uuid}',
@@ -496,6 +521,130 @@ class TestProjectSearchResultsView(
             len([p for p in self.plugins if (p.search_enable)]),
         )
         self.assertEqual(len(response.context['project_results']), 1)
+
+    def test_get_keywords_quoted(self):
+        """Test GET with quoted keywords and check that they are parsed OK"""
+        with self.login(self.user):
+            response = self.client.get(
+                reverse('projectroles:search')
+                + '?'
+                + urlencode({'s': 'test "test quoted" project:"white space"'})
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context['search_terms'], ['test', 'test quoted']
+        )
+        self.assertEqual(
+            response.context['search_keywords'],
+            {'project': 'white space'},
+        )
+        self.assertEqual(response.context['search_type'], None)
+        self.assertQuerySetEqual(
+            response.context['search_projects'], Project.objects.none()
+        )
+        self.assertEqual(
+            response.context['search_input'],
+            'test "test quoted" project:"white space"',
+        )
+        self.assertEqual(
+            len(response.context['app_results']),
+            len([p for p in self.plugins if (p.search_enable)]),
+        )
+
+    def test_get_keywords_project_title(self):
+        """Test GET with project:<title> in keywords"""
+        with self.login(self.user):
+            response = self.client.get(
+                reverse('projectroles:search')
+                + '?'
+                + urlencode({'s': f'test project:"{self.project.title}"'})
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['search_terms'], ['test'])
+        self.assertEqual(
+            response.context['search_keywords'],
+            {'project': self.project.title.lower()},
+        )
+        self.assertEqual(response.context['search_type'], None)
+        self.assertQuerySetEqual(
+            response.context['search_projects'],
+            Project.objects.filter(title=self.project.title),
+        )
+        self.assertEqual(
+            response.context['search_input'],
+            f'test project:"{self.project.title}"',
+        )
+        self.assertEqual(
+            len(response.context['app_results']),
+            len([p for p in self.plugins if (p.search_enable)]),
+        )
+        self.assertEqual(len(response.context['project_results']), 1)
+
+    def test_get_keywords_category_title(self):
+        """Test GET with project:<category title> in keywords"""
+        with self.login(self.user):
+            response = self.client.get(
+                reverse('projectroles:search')
+                + '?'
+                + urlencode({'s': f'test project:"{self.category.title}"'})
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['search_terms'], ['test'])
+        self.assertEqual(
+            response.context['search_keywords'],
+            {'project': self.category.title.lower()},
+        )
+        self.assertEqual(response.context['search_type'], None)
+        self.assertQuerySetEqual(
+            response.context['search_projects'],
+            Project.objects.filter(
+                full_title__startswith=self.category.full_title
+            ),
+        )
+        self.assertEqual(
+            response.context['search_input'],
+            f'test project:"{self.category.title}"',
+        )
+        self.assertEqual(
+            len(response.context['app_results']),
+            len([p for p in self.plugins if (p.search_enable)]),
+        )
+
+    def test_get_search_string_parsing(self):
+        """Test GET with a challenging string and check that it is parsed OK"""
+        with self.login(self.user):
+            response = self.client.get(
+                reverse('projectroles:search')
+                + '?'
+                + urlencode(
+                    {
+                        's': (
+                            'key1:value1  "term with spaces"\t'
+                            'key2:"value2 with spaces"\t term2\n"key3:value3"'
+                        )
+                    }
+                )
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context['search_terms'], ['term with spaces', 'term2']
+        )
+        self.assertEqual(
+            response.context['search_keywords'],
+            {'key1': 'value1', 'key2': 'value2 with spaces', 'key3': 'value3'},
+        )
+        self.assertEqual(response.context['search_type'], None)
+        self.assertEqual(
+            response.context['search_input'],
+            (
+                'key1:value1  "term with spaces"\t'
+                'key2:"value2 with spaces"\t term2\n"key3:value3"'
+            ),
+        )
+        self.assertEqual(
+            len(response.context['app_results']),
+            len([p for p in self.plugins if (p.search_enable)]),
+        )
 
     def test_get_keywords_missing(self):
         """Test GET with incomplete keyword missing the value"""
@@ -509,19 +658,10 @@ class TestProjectSearchResultsView(
         self.assertEqual(response.context['search_terms'], ['test'])
         self.assertEqual(response.context['search_keywords'], {'project': ''})
         self.assertQuerySetEqual(
-            response.context['search_projects'], Project.objects.none()
+            response.context['search_projects'], Project.objects.all()
         )
         self.assertEqual(response.context['search_type'], None)
         self.assertEqual(response.context['search_input'], 'test project:')
-        self.assertEqual(
-            len(response.context['app_results']),
-            len([p for p in self.plugins if (p.search_enable)]),
-        )
-        self.assertEqual(
-            [app['has_results'] for app in response.context['app_results']],
-            [False] * len([p for p in self.plugins if (p.search_enable)]),
-        )
-        self.assertEqual(len(response.context['project_results']), 0)
 
     def test_get_non_text_input(self):
         """Test GET with non-text input from standard search (should redirect)"""
@@ -689,6 +829,35 @@ class TestProjectSearchResultsView(
         )
         self.assertEqual(len(response.context['project_results']), 0)
 
+    def test_post_advanced_search_string_parsing(self):
+        """Test POST from ProjectAdvancedSearchView"""
+        with self.login(self.user):
+            response = self.client.post(
+                reverse('projectroles:search_advanced'),
+                data={
+                    'm': 'test with spaces\r\ntestproject\r\nxxx',
+                    'k': 'type:project project:"project with spaces"',
+                },
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context['search_input'],
+            '\'test with spaces\' testproject xxx',
+        )
+        self.assertEqual(
+            response.context['search_terms'],
+            ['test with spaces', 'testproject', 'xxx'],
+        )
+        self.assertEqual(
+            response.context['search_type'],
+            'project',
+        )
+        self.assertEqual(
+            response.context['search_keywords'],
+            {'project': 'project with spaces'},
+        )
+        self.assertEqual(response.context['search_type'], 'project')
+
     @override_settings(PROJECTROLES_ENABLE_SEARCH=False)
     def test_get_disabled(self):
         """Test GET with disabled search"""
@@ -732,7 +901,7 @@ class TestProjectSearchResultsView(
             self.assertEqual(len(response.context['app_results']), 1)
 
     def test_get_app_search_results_within_project(self):
-        """Test GET app search results within project"""
+        """Test GET app search results within project by UUID"""
         with self.login(self.user):
             response = self.client.get(
                 reverse('projectroles:search')
@@ -740,6 +909,21 @@ class TestProjectSearchResultsView(
                 + urlencode(
                     {'s': 'test_event project:{self.project.sodar_uuid}'}
                 )
+            )
+        # Events are not found when search is restricted to `self.project`
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['app_results']), 2)
+        for app_result in response.context['app_results']:
+            if app_result['plugin'] == 'timeline':
+                self.assertFalse(app_result['has_results'])
+
+    def test_get_app_search_results_within_project_by_title(self):
+        """Test GET app search results within project by title"""
+        with self.login(self.user):
+            response = self.client.get(
+                reverse('projectroles:search')
+                + '?'
+                + urlencode({'s': 'test_event project:"{self.project.title}"'})
             )
         # Events are not found when search is restricted to `self.project`
         self.assertEqual(response.status_code, 200)
@@ -772,6 +956,21 @@ class TestProjectSearchResultsView(
                 + urlencode(
                     {'s': 'test_event project:{self.category.sodar_uuid}'}
                 )
+            )
+        # Events are found when search is restricted to the parent category
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['app_results']), 2)
+        for app_result in response.context['app_results']:
+            if app_result['plugin'] == 'timeline':
+                self.assertTrue(app_result['has_results'])
+
+    def test_get_app_search_results_within_category_by_title(self):
+        """Test GET app search results within category by title"""
+        with self.login(self.user):
+            response = self.client.get(
+                reverse('projectroles:search')
+                + '?'
+                + urlencode({'s': 'test_event project:{self.category.title}'})
             )
         # Events are found when search is restricted to the parent category
         self.assertEqual(response.status_code, 200)

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -443,7 +443,7 @@ class TestProjectSearchResultsView(
         )
 
     def test_get_quoted(self):
-        """Test ProjectSearchResultsView GET with quoted search term"""
+        """Test GET with quoted search term"""
         with self.login(self.user):
             response = self.client.get(
                 reverse('projectroles:search')
@@ -830,7 +830,7 @@ class TestProjectSearchResultsView(
         self.assertEqual(len(response.context['project_results']), 0)
 
     def test_post_advanced_search_string_parsing(self):
-        """Test POST from ProjectAdvancedSearchView"""
+        """Test POST from ProjectAdvancedSearchView with a challenging string"""
         with self.login(self.user):
             response = self.client.post(
                 reverse('projectroles:search_advanced'),
@@ -856,7 +856,22 @@ class TestProjectSearchResultsView(
             response.context['search_keywords'],
             {'project': 'project with spaces'},
         )
-        self.assertEqual(response.context['search_type'], 'project')
+
+    def test_post_advanced_search_quoted_string_parsing(self):
+        """Test POST from ProjectAdvancedSearchView with quoted search terms"""
+        with self.login(self.user):
+            response = self.client.post(
+                reverse('projectroles:search_advanced'),
+                data={
+                    'm': 'alert test\r\n"alert test"',
+                    'k': '',
+                },
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context['search_terms'],
+            ['alert test'],
+        )
 
     @override_settings(PROJECTROLES_ENABLE_SEARCH=False)
     def test_get_disabled(self):
@@ -910,7 +925,7 @@ class TestProjectSearchResultsView(
                     {'s': 'test_event project:{self.project.sodar_uuid}'}
                 )
             )
-        # Events are not found when search is restricted to `self.project`
+        # Events are not found when search is restricted to self.project
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['app_results']), 2)
         for app_result in response.context['app_results']:
@@ -925,7 +940,7 @@ class TestProjectSearchResultsView(
                 + '?'
                 + urlencode({'s': 'test_event project:"{self.project.title}"'})
             )
-        # Events are not found when search is restricted to `self.project`
+        # Events are not found when search is restricted to self.project
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['app_results']), 2)
         for app_result in response.context['app_results']:
@@ -940,7 +955,7 @@ class TestProjectSearchResultsView(
                 + '?'
                 + urlencode({'s': 'test_event project:{project_new}'})
             )
-        # Events are found when search is restricted to `project_new`
+        # Events are found when search is restricted to project_new
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['app_results']), 2)
         for app_result in response.context['app_results']:

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -842,7 +842,7 @@ class TestProjectSearchResultsView(
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.context['search_input'],
-            '\'test with spaces\' testproject xxx',
+            '',
         )
         self.assertEqual(
             response.context['search_terms'],

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -867,9 +867,9 @@ class ProjectSearchResultsView(
 
         if self.request.POST.get('m'):  # Multi search
             search_terms = [
-                t.strip()
+                t.strip().strip('\'"')
                 for t in self.request.POST['m'].strip().split('\r\n')
-                if len(t.strip()) >= 3
+                if len(t.strip().strip('\'"')) >= 3
             ]
             search_input = shlex.join(search_terms)
             if self.request.POST.get('k'):

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import shlex
+import uuid
 
 from ipaddress import ip_address, ip_network
 from typing import Any, Optional, Union
@@ -13,7 +14,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib import auth, messages
 from django.contrib.auth.mixins import AccessMixin
-from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, Http404
@@ -882,7 +883,7 @@ class ProjectSearchResultsView(
                 else:
                     search_terms.append(token.lower())
 
-        search_terms = list(set(search_terms))  # Remove dupes
+        search_terms = list(dict.fromkeys(search_terms))  # Remove dupes
 
         for s in keyword_input:
             kw = s.split(':')[0].lower().strip()
@@ -894,13 +895,17 @@ class ProjectSearchResultsView(
 
         if 'project' in search_keywords:
             try:
-                sodar_uuid = search_keywords['project']
+                sodar_uuid = uuid.UUID(search_keywords['project'])
                 parent = Project.objects.get(sodar_uuid=sodar_uuid)
                 search_projects = Project.objects.filter(
                     full_title__startswith=parent.full_title
                 )
-            except ValidationError:
-                logger.debug("Invalid UUID provided to search")
+            except ValueError:
+                # Not a valid UUID, trying to match project title directly
+                search_projects = Project.objects.filter(
+                    full_title__icontains=search_keywords['project']
+                )
+            except Project.DoesNotExist:
                 search_projects = Project.objects.none()
         else:
             search_projects = Project.objects.all()

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import re
+import shlex
 
 from ipaddress import ip_address, ip_network
 from typing import Any, Optional, Union
@@ -869,21 +870,19 @@ class ProjectSearchResultsView(
                 for t in self.request.POST['m'].strip().split('\r\n')
                 if len(t.strip()) >= 3
             ]
+            search_input = shlex.join(search_terms)
             if self.request.POST.get('k'):
-                keyword_input = self.request.POST['k'].strip().split(' ')
+                keyword_input = shlex.split(self.request.POST['k'])
         elif self.request.GET.get('s'):  # Single search
             search_input = self.request.GET.get('s').strip()
-            search_split = search_input.split(' ')
-            search_term = search_split[0].strip()
-            for i in range(1, len(search_split)):
-                s = search_split[i].strip()
-                if ':' in s:
-                    keyword_input.append(s)
-                elif s != '':
-                    search_term += ' ' + s.lower()
-            if search_term:
-                search_terms = [search_term]
-        search_terms = list(dict.fromkeys(search_terms))  # Remove dupes
+            search_split = shlex.split(search_input)
+            for token in search_split:
+                if ':' in token:
+                    keyword_input.append(token)
+                else:
+                    search_terms.append(token.lower())
+
+        search_terms = list(set(search_terms))  # Remove dupes
 
         for s in keyword_input:
             kw = s.split(':')[0].lower().strip()

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -871,7 +871,6 @@ class ProjectSearchResultsView(
                 for t in self.request.POST['m'].strip().split('\r\n')
                 if len(t.strip().strip('\'"')) >= 3
             ]
-            search_input = shlex.join(search_terms)
             if self.request.POST.get('k'):
                 keyword_input = shlex.split(self.request.POST['k'])
         elif self.request.GET.get('s'):  # Single search


### PR DESCRIPTION
This PR attempts to solve #1898 and address the second point of [this comment](https://github.com/bihealth/sodar-core/issues/1899#issuecomment-4005604798) in #1899. I used the `shlex` module to parse the search string in a way that preserves the quotes. As a side effect, search terms can now also be quoted. I also updated the docs about the signature for the search() function.