### PR TITLE
Replace Black and Flake8 with Ruff (#1881)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,11 +58,11 @@ jobs:
           coverage run --rcfile=.coveragerc manage.py test -v 2 --settings=config.settings.test
           coverage lcov
           coverage report
-      - name: Check linting
-        run: flake8 .
-        if: ${{ matrix.python-version == '3.13' }}
       - name: Check formatting
-        run: ruff check
+        run: make format-check
+        if: ${{ matrix.python-version == '3.13' }}
+      - name: Check linting
+        run: make lint
         if: ${{ matrix.python-version == '3.13' }}
       - name: Check docs building
         working-directory: ./docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,6 @@ jobs:
         run: python manage.py geticons --settings=config.settings.test
       - name: Run collectstatic
         run: python manage.py collectstatic --noinput --settings=config.settings.test
-      - name: Run tests
-        run: |
-          coverage run --rcfile=.coveragerc manage.py test -v 2 --settings=config.settings.test
-          coverage lcov
-          coverage report
       - name: Check formatting
         run: make format-check
         if: ${{ matrix.python-version == '3.13' }}
@@ -68,6 +63,11 @@ jobs:
         working-directory: ./docs
         run: make html
         if: ${{ matrix.python-version == '3.13' }}
+      - name: Run tests
+        run: |
+          coverage run --rcfile=.coveragerc manage.py test -v 2 --settings=config.settings.test
+          coverage lcov
+          coverage report
       - name: Report coverage with Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: flake8 .
         if: ${{ matrix.python-version == '3.13' }}
       - name: Check formatting
-        run: make black arg=--check
+        run: ruff check
         if: ${{ matrix.python-version == '3.13' }}
       - name: Check docs building
         working-directory: ./docs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,6 @@ all_tests:
     - python3 manage.py collectstatic --noinput
     - coverage run --source="." manage.py test -v 2 --settings=config.settings.test
     - coverage report
-    - ruff check
-    - flake8 .
+    - make format-check
+    - make lint
   when: on_success

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,6 @@ all_tests:
     - python3 manage.py collectstatic --noinput
     - coverage run --source="." manage.py test -v 2 --settings=config.settings.test
     - coverage report
-    - make black arg=--check
+    - ruff check
     - flake8 .
   when: on_success

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Changed
     - General documentation updates (#1884)
     - Replace black and flake8 with ruff for linting and formatting (#1881)
     - Update ``Makefile`` for new check, format and lint commands (#1881)
+    - Move tests after formatting and docs checks in CI (#1907)
 - **Projectroles**
     - Make ``modify_assignment()`` ``request`` arg optional (#1875)
     - Update default single sign-on button legend (#1883)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Added
     - ``HostConfirmDeleteView`` for delete views with host confirmation (#1550)
     - ``transferroles`` management command (#1869)
     - Remote sync user ``active`` status (#1882)
+    - Project limiting in search via ``project`` keyword (#1191, #1898)
+    - Plugin search API ``projects`` queryset kwarg (#1899)
 - **Siteinfo**
     - Client-side statistics retrieval (#1848)
 
@@ -33,6 +35,8 @@ Changed
     - Replace black and flake8 with ruff for linting and formatting (#1881)
     - Update ``Makefile`` for new check, format and lint commands (#1881)
     - Move tests after formatting and docs checks in CI (#1907)
+    - Move plugin search API ``search_type`` in keywords (#1901)
+    - Replace plugin search API ``keywords`` kwarg with ``**kwargs`` (#1902)
 - **Projectroles**
     - Make ``modify_assignment()`` ``request`` arg optional (#1875)
     - Update default single sign-on button legend (#1883)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Changed
     - Upgrade general Python dependencies (#1878)
     - Replace markupfield and pagedown with martor (#1861)
     - General documentation updates (#1884)
+    - Replace black and flake8 with ruff for linting and formatting (#1881)
+    - Update ``Makefile`` for new check, format and lint commands (#1881)
 - **Projectroles**
     - Make ``modify_assignment()`` ``request`` arg optional (#1875)
     - Update default single sign-on button legend (#1883)
@@ -50,6 +52,9 @@ Fixed
 Removed
 -------
 
+- **General**
+    - Black and flake8 dependencies (#1881)
+    - Legacy flake8 and pycodestyle configuration (#1881)
 - **Projectroles**
     - ``AppSetting.user_modifiable`` field (#1721)
     - Deprecated base test classes and mixins (#1830)

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,7 @@ collectstatic:
 
 
 .PHONY: check
-check:
-	ruff format --check
-	ruff check $(arg)
+check: format-check lint
 
 
 .PHONY: js-beautify

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,17 @@ MANAGE = python manage.py
 define USAGE=
 @echo -e
 @echo -e "Usage:"
-@echo -e "\tmake black [arg=--<arg>]                 -- black formatting"
+@echo -e "\tmake black [arg=--<arg>]                 -- format Python with black (to be removed)"
+@echo -e "\tmake celery                              -- start celery worker"
+@echo -e "\tmake collectstatic                       -- run collectstatic"
 @echo -e "\tmake flake                               -- run flake8"
 @echo -e "\tmake js-beautify arg=<path>              -- run js-beautify on Javascript file(s)"
-@echo -e "\tmake celery                              -- start celery worker"
+@echo -e "\tmake manage_target arg=<target_command>  -- run management command on target site, arg is mandatory"
+@ecto -e "\tmake ruff                                -- format Python with ruff
 @echo -e "\tmake serve                               -- start source server"
 @echo -e "\tmake serve_target                        -- start target server"
-@echo -e "\tmake collectstatic                       -- run collectstatic"
-@echo -e "\tmake test [arg=<test_object>]            -- run all tests or specify module/class/function"
-@echo -e "\tmake manage_target arg=<target_command>  -- run management command on target site, arg is mandatory"
 @echo -e "\tmake spectacular                         -- generate OpenAPI schemas with drf-spectacular"
+@echo -e "\tmake test [arg=<test_object>]            -- run all tests or specify module/class/function"
 @echo -e
 endef
 
@@ -28,6 +29,16 @@ black:
 	black . $(arg)
 
 
+.PHONY: celery
+celery:
+	celery -A config worker -l info --beat
+
+
+.PHONY: collectstatic
+collectstatic:
+	$(MANAGE) collectstatic --no-input
+
+
 .PHONY: flake
 flake:
 	flake8 .
@@ -36,31 +47,6 @@ flake:
 .PHONY: js-beautify
 js-beautify:
 	js-beautify -anr -s 2 -w 80 $(arg)
-
-
-.PHONY: celery
-celery:
-	celery -A config worker -l info --beat
-
-
-.PHONY: serve
-serve:
-	$(MANAGE) runserver --settings=config.settings.local
-
-
-.PHONY: serve_target
-serve_target:
-	$(MANAGE) runserver 0.0.0.0:$(target_port) --settings=config.settings.local_target
-
-
-.PHONY: collectstatic
-collectstatic:
-	$(MANAGE) collectstatic --no-input
-
-
-.PHONY: test
-test: collectstatic
-	$(MANAGE) test -v 2 --parallel --settings=config.settings.test $(arg)
 
 
 .PHONY: manage_target
@@ -74,12 +60,31 @@ else
 endif
 
 
+.PHONY: ruff
+ruff:
+	ruff format $(arg)
+
+
+.PHONY: serve
+serve:
+	$(MANAGE) runserver --settings=config.settings.local
+
+
+.PHONY: serve_target
+serve_target:
+	$(MANAGE) runserver 0.0.0.0:$(target_port) --settings=config.settings.local_target
+
+
 .PHONY: spectacular
 spectacular:
 	$(MANAGE) spectacular --color $(arg)
 
 
+.PHONY: test
+test: collectstatic
+	$(MANAGE) test -v 2 --parallel --settings=config.settings.test $(arg)
+
+
 .PHONY: usage
 usage:
 	$(USAGE)
-

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,13 @@ define USAGE=
 @echo -e "Usage:"
 @echo -e "\tmake black [arg=--<arg>]                 -- format Python with black (to be removed)"
 @echo -e "\tmake celery                              -- start celery worker"
+@echo -e "\tmake check                               -- check Python code linting and formatting"
 @echo -e "\tmake collectstatic                       -- run collectstatic"
-@echo -e "\tmake flake                               -- run flake8"
 @echo -e "\tmake js-beautify arg=<path>              -- run js-beautify on Javascript file(s)"
 @echo -e "\tmake manage_target arg=<target_command>  -- run management command on target site, arg is mandatory"
-@ecto -e "\tmake ruff                                -- format Python with ruff
+@echo -e "\tmake format                              -- format Python code"
+@echo -e "\tmake format-check                        -- check Python code formatting"
+@echo -e "\tmake lint                                -- lint Python code"
 @echo -e "\tmake serve                               -- start source server"
 @echo -e "\tmake serve_target                        -- start target server"
 @echo -e "\tmake spectacular                         -- generate OpenAPI schemas with drf-spectacular"
@@ -39,9 +41,10 @@ collectstatic:
 	$(MANAGE) collectstatic --no-input
 
 
-.PHONY: flake
-flake:
-	flake8 .
+.PHONY: check
+check:
+	ruff format --check
+	ruff check $(arg)
 
 
 .PHONY: js-beautify
@@ -60,9 +63,19 @@ else
 endif
 
 
-.PHONY: ruff
-ruff:
+.PHONY: format
+format:
 	ruff format $(arg)
+
+
+.PHONY: format-check
+format-check:
+	ruff format --check
+
+
+.PHONY: lint
+lint:
+	ruff check $(arg)
 
 
 .PHONY: serve

--- a/adminalerts/migrations/0001_squashed_0006_adminalert_require_auth.py
+++ b/adminalerts/migrations/0001_squashed_0006_adminalert_require_auth.py
@@ -8,7 +8,6 @@ import uuid
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ('adminalerts', '0001_initial'),
         ('adminalerts', '0002_adminalert_user'),

--- a/adminalerts/migrations/0007_remove_adminalert__description_rendered_and_more.py
+++ b/adminalerts/migrations/0007_remove_adminalert__description_rendered_and_more.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('adminalerts', '0001_squashed_0006_adminalert_require_auth'),
     ]

--- a/adminalerts/views.py
+++ b/adminalerts/views.py
@@ -39,17 +39,17 @@ User = get_user_model()
 APP_NAME = 'adminalerts'
 DEFAULT_PAGINATION = 15
 EMAIL_SUBJECT = '{state} admin alert: {message}'
-EMAIL_BODY = r'''
+EMAIL_BODY = r"""
 An admin alert has been {action}d by {issuer}:
 
 {message}
-'''.lstrip()
-EMAIL_BODY_DESCRIPTION = r'''
+""".lstrip()
+EMAIL_BODY_DESCRIPTION = r"""
 Additional details:
 ----------------------------------------
 {description}
 ----------------------------------------
-'''
+"""
 
 
 # Listing/details views --------------------------------------------------------

--- a/appalerts/migrations/0001_initial.py
+++ b/appalerts/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import uuid
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/bgjobs/migrations/0001_squashed_0006_auto_20200526_1657.py
+++ b/bgjobs/migrations/0001_squashed_0006_auto_20200526_1657.py
@@ -7,7 +7,6 @@ import uuid
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ('bgjobs', '0001_initial'),
         ('bgjobs', '0002_backgroundjoblogentry'),
@@ -132,7 +131,7 @@ class Migration(migrations.Migration):
                         max_length=50,
                     ),
                 ),
-                ('message', models.TextField(help_text='Log level\'s message')),
+                ('message', models.TextField(help_text="Log level's message")),
                 (
                     'job',
                     models.ForeignKey(

--- a/bgjobs/models.py
+++ b/bgjobs/models.py
@@ -96,7 +96,7 @@ class BackgroundJob(models.Model):
     )
 
     class Meta:
-        ordering = ["-date_created"]
+        ordering = ['-date_created']
 
     def get_human_readable_type(self) -> str:
         """

--- a/bgjobs/templatetags/bgjobs_tags.py
+++ b/bgjobs/templatetags/bgjobs_tags.py
@@ -32,9 +32,9 @@ def specialize_job(bg_job: BackgroundJob) -> BackgroundJob:
     job_specs = {}
     # Setup the global map
     for plugin in BackgroundJobsPluginPoint.get_plugins():
-        assert not (
-            set(plugin.job_specs) & set(job_specs)
-        ), 'Registering model twice!'
+        assert not (set(plugin.job_specs) & set(job_specs)), (
+            'Registering model twice!'
+        )
         job_specs.update(plugin.job_specs)
 
     klass = job_specs.get(bg_job.job_type)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -291,14 +291,8 @@ AUTH_PASSWORD_VALIDATORS = [
         'NAME': 'django.contrib.auth.password_validation.'
         'UserAttributeSimilarityValidator'
     },
-    {
-        'NAME': 'django.contrib.auth.password_validation.'
-        'MinimumLengthValidator'
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.'
-        'CommonPasswordValidator'
-    },
+    {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator'},
+    {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'},
     {
         'NAME': 'django.contrib.auth.password_validation.'
         'NumericPasswordValidator'

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -85,14 +85,15 @@ Ready to contribute code to SODAR Core? Here are the steps to get started.
 
     $ git checkout -b 123-branch-name dev
 
-5. When you're done making changes, make sure to apply proper formatting using
-   Black. Next, check linting with flake8. Finally, run the tests.::
+5. When you're done making changes, make sure to apply proper formatting and run
+   linting to ensure the correct code style. Finally, run the tests. ::
 
-    $ make black
-    $ flake8 .
+    $ make format
+    $ make lint
     $ make test
 
-6. Once flake8 and tests, commit your changes and push your branch to GitHub. ::
+6. Once the checks and tests pass, commit your changes and push your branch to
+   GitHub. ::
 
     $ git add .
     $ git commit -m "add/update/fix issue-description-here (#issue-id)"

--- a/docs/source/dev_core_guide.rst
+++ b/docs/source/dev_core_guide.rst
@@ -43,8 +43,8 @@ Before submitting a pull request for review, ensure the following:
 - You have updated documentation if your pull requests adds or modifies features
   (see :ref:`dev_core_guide_doc`).
 - All tests pass with ``make test``.
-- ``make black`` has been run for the latest commit.
-- ``make flake8`` produces no errors.
+- ``make format`` has been run for the latest commit.
+- ``make lint`` produces no errors.
 - ``make js-beautify arg=$filename`` has been run for any updated JQuery files.
 
 Your pull request should work on the Python versions currently supported by the
@@ -77,7 +77,7 @@ The following conventions should be adhered to in SODAR Core development:
     * Exception: Documentation syntax where this can not be avoided, e.g. long
       references in RST.
 - Use single quotes instead of double quotes for variables.
-    * Black does not enforce this, so they have to be ensured manually.
+    * Ruff formatting will enforce this.
 - Do not use RST syntax in docstrings or comments.
     * Exception: Docstrings for REST API endpoint methods.
 - Provide type hints for functions you declare.

--- a/docs/source/major_changes.rst
+++ b/docs/source/major_changes.rst
@@ -23,6 +23,8 @@ Release Highlights
 - Add user active status in remote sync
 - Add general purpose HTTP 503 API exception class
 - Replace Markupfield and Pagedown with Martor for Markdown rendering
+- Replace Black and Flake8 with Ruff for linting and formatting
+- Update Makefile for new check, format and lint commands
 - Fix batchupdateroles role promoting
 - Fix app setting API get() exception handling with PROJECT_USER scope
 - Remove deprecated test base classes and mixins

--- a/docs/source/major_changes.rst
+++ b/docs/source/major_changes.rst
@@ -24,7 +24,7 @@ Release Highlights
 - Add general purpose HTTP 503 API exception class
 - Replace Markupfield and Pagedown with Martor for Markdown rendering
 - Replace Black and Flake8 with Ruff for linting and formatting
-- Update Makefile for new check, format and lint commands
+- Update Makefile for check, format and lint commands
 - Fix batchupdateroles role promoting
 - Fix app setting API get() exception handling with PROJECT_USER scope
 - Remove deprecated test base classes and mixins

--- a/docs/source/major_changes.rst
+++ b/docs/source/major_changes.rst
@@ -16,12 +16,15 @@ v1.4.0 (WIP)
 Release Highlights
 ==================
 
+- Add project limiting to search via UUID or partial title
 - Add client-side siteinfo statistics retrieval
 - Add reusable host confirmation delete view
 - Add transferroles management command
 - Add optional user name display in user dropdown
 - Add user active status in remote sync
+- Add plugin search API pre-filtered project queryset
 - Add general purpose HTTP 503 API exception class
+- Update plugin search API args for project queryset and simplified keywords
 - Replace Markupfield and Pagedown with Martor for Markdown rendering
 - Replace Black and Flake8 with Ruff for linting and formatting
 - Update Makefile for check, format and lint commands

--- a/docs/source/repository.rst
+++ b/docs/source/repository.rst
@@ -74,15 +74,15 @@ Relevant files in the root of the repository are detailed here.
 ``manage.py``
     The Django file for running management commands.
 ``pyproject.toml``
-    Settings for building and Black.
+    Settings for package building, Python linting and Python formatting.
 ``README.rst``
     The project readme.
 ``requirements.txt``
     Requirements file placed here for compatibility. Actual requirements can be
     found in ``requirements/*.txt``.
 ``setup.cfg``
-    Settings for Flake8, Pycodestyle and Versioneer. Generally these should not
-    be touched.
+    Settings for Versioneer and possible other components using legacy
+    configuration. Generally these should not be touched.
 ``setup.py``
     The setup file for the ``django-sodar-core`` package.
 ``versioneer.py``

--- a/example_site/contrib/sites/migrations/0001_initial.py
+++ b/example_site/contrib/sites/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = []
 
     operations = [

--- a/example_site/contrib/sites/migrations/0002_alter_domain_unique.py
+++ b/example_site/contrib/sites/migrations/0002_alter_domain_unique.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('sites', '0001_initial'),
     ]

--- a/example_site/contrib/sites/migrations/0003_set_site_domain_and_name.py
+++ b/example_site/contrib/sites/migrations/0003_set_site_domain_and_name.py
@@ -27,7 +27,6 @@ def update_site_backward(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('sites', '0002_alter_domain_unique'),
     ]

--- a/example_site/contrib/sites/migrations/0004_auto_20210225_1545.py
+++ b/example_site/contrib/sites/migrations/0004_auto_20210225_1545.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('sites', '0003_set_site_domain_and_name'),
     ]

--- a/example_site/users/apps.py
+++ b/example_site/users/apps.py
@@ -3,7 +3,7 @@ from django.apps import AppConfig
 
 class UsersConfig(AppConfig):
     name = 'example_site.users'
-    verbose_name = "Users"
+    verbose_name = 'Users'
 
     def ready(self):
         """Override this to put in:

--- a/example_site/users/auth.py
+++ b/example_site/users/auth.py
@@ -21,9 +21,9 @@ class FallbackToAuthBasicMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         # Authentication middleware must be active.
-        assert hasattr(
-            request, 'user'
-        ), 'AuthenticationMiddleware must be active'
+        assert hasattr(request, 'user'), (
+            'AuthenticationMiddleware must be active'
+        )
         # We are already done if the user is already authenticated.
         if request.user.is_authenticated:
             return

--- a/example_site/users/migrations/0001_initial.py
+++ b/example_site/users/migrations/0001_initial.py
@@ -10,7 +10,6 @@ import uuid
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/example_site/users/migrations/0002_auto_20180904_1002.py
+++ b/example_site/users/migrations/0002_auto_20180904_1002.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('users', '0001_initial'),
     ]

--- a/example_site/users/migrations/0003_rename_uuid.py
+++ b/example_site/users/migrations/0003_rename_uuid.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('users', '0002_auto_20180904_1002'),
     ]

--- a/example_site/users/migrations/0004_update_uuid.py
+++ b/example_site/users/migrations/0004_update_uuid.py
@@ -7,7 +7,6 @@ import uuid
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('users', '0003_rename_uuid'),
     ]

--- a/example_site/users/migrations/0005_update_ordering.py
+++ b/example_site/users/migrations/0005_update_ordering.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('users', '0004_update_uuid'),
     ]

--- a/example_site/users/migrations/0006_auto_20210225_1545.py
+++ b/example_site/users/migrations/0006_auto_20210225_1545.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('users', '0005_update_ordering'),
     ]

--- a/example_site/users/migrations/0007_user_enable_update.py
+++ b/example_site/users/migrations/0007_user_enable_update.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('users', '0006_auto_20210225_1545'),
     ]

--- a/filesfolders/migrations/0001_squashed_0005_alter_foreignkey_fields.py
+++ b/filesfolders/migrations/0001_squashed_0005_alter_foreignkey_fields.py
@@ -7,7 +7,6 @@ import uuid
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ('filesfolders', '0001_initial'),
         ('filesfolders', '0002_auto_20180411_1758'),

--- a/filesfolders/migrations/0006_alter_file_unique_together_and_more.py
+++ b/filesfolders/migrations/0006_alter_file_unique_together_and_more.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('filesfolders', '0001_squashed_0005_alter_foreignkey_fields'),
         ('projectroles', '0041_alter_appsetting_unique_together_and_more'),

--- a/filesfolders/templatetags/filesfolders_tags.py
+++ b/filesfolders/templatetags/filesfolders_tags.py
@@ -63,8 +63,8 @@ def get_file_icon(file: File) -> str:
         ret = 'archive-outline'
     elif (
         'excel' in mt
-        or mt == 'application/vnd.openxmlformats-'
-        'officedocument.spreadsheetml.sheet'
+        or mt
+        == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     ):
         ret = 'file-excel-outline'
     elif 'image/' in mt:
@@ -82,8 +82,9 @@ def get_flag(flag_name: str, tooltip: bool = True) -> str:
     tip_str = ''
     if tooltip:
         tip_str = (
-            'title="{}" data-toggle="tooltip" '
-            'data-placement="top"'.format(f['label'])
+            'title="{}" data-toggle="tooltip" data-placement="top"'.format(
+                f['label']
+            )
         )
     return (
         '<i class="iconify text-{} sodar-ff-flag-icon" data-icon="{}" {}>'

--- a/filesfolders/tests/test_permissions_api.py
+++ b/filesfolders/tests/test_permissions_api.py
@@ -659,7 +659,7 @@ class TestFileListCreateAPIView(FilesfoldersAPIPermissionTestBase):
         self.post_data = {
             'name': 'New File',
             'flag': 'IMPORTANT',
-            'description': 'File\'s description',
+            'description': "File's description",
             'secret': 'foo',
             'public_url': True,
             'file': open(ZIP_PATH_NO_FILES, 'rb'),

--- a/filesfolders/tests/test_views_api.py
+++ b/filesfolders/tests/test_views_api.py
@@ -51,7 +51,7 @@ class TestFolderListCreateAPIView(FilesfoldersAPIViewTestBase):
         self.folder_data = {
             'name': 'New Folder',
             'flag': 'IMPORTANT',
-            'description': 'Folder\'s description',
+            'description': "Folder's description",
         }
         self.url = reverse(
             'filesfolders:api_folder_list_create',
@@ -237,7 +237,7 @@ class TestFileListCreateAPIView(FilesfoldersAPIViewTestBase):
         self.file_data = {
             'name': 'New File',
             'flag': 'IMPORTANT',
-            'description': 'File\'s description',
+            'description': "File's description",
             'secret': 'foo',
             'public_url': True,
             'file': open(ZIP_PATH_NO_FILES, 'rb'),
@@ -491,7 +491,7 @@ class TestHyperLinkListCreateAPIView(FilesfoldersAPIViewTestBase):
         self.hyperlink_data = {
             'name': 'New HyperLink',
             'flag': 'IMPORTANT',
-            'description': 'HyperLink\'s description',
+            'description': "HyperLink's description",
             'url': 'http://www.cubi.bihealth.org',
         }
         self.url = reverse(

--- a/manage.py
+++ b/manage.py
@@ -16,8 +16,8 @@ if __name__ == '__main__':
         except ImportError:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "
-                "available on your PYTHONPATH environment variable? Did you "
-                "forget to activate a virtual environment?"
+                'available on your PYTHONPATH environment variable? Did you '
+                'forget to activate a virtual environment?'
             )
         raise
 

--- a/projectroles/__init__.py
+++ b/projectroles/__init__.py
@@ -6,6 +6,4 @@ from . import _version  # noqa
 
 __version__ = _version.get_versions()['version']
 
-default_app_config = (
-    'projectroles.apps.ProjectrolesConfig'  # pylint: disable=invalid-name
-)
+default_app_config = 'projectroles.apps.ProjectrolesConfig'  # pylint: disable=invalid-name

--- a/projectroles/app_links.py
+++ b/projectroles/app_links.py
@@ -172,7 +172,7 @@ class AppLinkAPI:
                 if self._is_app_visible(plugin, project, user):
                     ret.append(
                         {
-                            'name': "app-plugin-" + plugin.name,
+                            'name': 'app-plugin-' + plugin.name,
                             'url': reverse(
                                 plugin.entry_point_url_id,
                                 kwargs={'project': project.sodar_uuid},

--- a/projectroles/email.py
+++ b/projectroles/email.py
@@ -49,31 +49,31 @@ EMAIL_RE = re.compile(r'(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)')
 # Generic Elements -------------------------------------------------------------
 
 
-MESSAGE_HEADER = r'''
+MESSAGE_HEADER = r"""
 Dear {recipient},
 
 This email has been automatically sent to you by {site_title}.
 
-'''.lstrip()
+""".lstrip()
 
-MESSAGE_HEADER_NO_RECIPIENT = r'''
+MESSAGE_HEADER_NO_RECIPIENT = r"""
 This email has been automatically sent to you by {site_title}.
-'''.lstrip()
+""".lstrip()
 
-NO_REPLY_NOTE = r'''
+NO_REPLY_NOTE = r"""
 Please do not reply to this email.
-'''
+"""
 
-MESSAGE_FOOTER = r'''
+MESSAGE_FOOTER = r"""
 
 For support and reporting issues regarding {site_title},
 contact {admin_name} ({admin_email}).
-'''
+"""
 
-SETTINGS_LINK = r'''
+SETTINGS_LINK = r"""
 You can manage receiving of automated emails in your user settings:
 {url}
-'''
+"""
 
 
 # Role Change Template ---------------------------------------------------------
@@ -84,33 +84,33 @@ SUBJECT_ROLE_UPDATE = 'Membership changed in {project_label} "{project}"'
 SUBJECT_ROLE_DELETE = 'Membership removed from {project_label} "{project}"'
 SUBJECT_ROLE_LEAVE = 'Member {user_name} left {project_label} "{project}"'
 
-MESSAGE_ROLE_CREATE = r'''
+MESSAGE_ROLE_CREATE = r"""
 {issuer} has granted you the membership
 in {project_label} "{project}" with the role of "{role}".
 
 To access the {project_label} in {site_title}, please click on
 the following link:
 {project_url}
-'''.lstrip()
+""".lstrip()
 
-MESSAGE_ROLE_UPDATE = r'''
+MESSAGE_ROLE_UPDATE = r"""
 {issuer} has changed your membership
 role in {project_label} "{project}" into "{role}".
 
 To access the {project_label} in {site_title}, please click on
 the following link:
 {project_url}
-'''.lstrip()
+""".lstrip()
 
-MESSAGE_ROLE_DELETE = r'''
+MESSAGE_ROLE_DELETE = r"""
 {issuer} has removed your membership from {project_label} "{project}".
-'''.lstrip()
+""".lstrip()
 
-MESSAGE_ROLE_LEAVE = r'''
+MESSAGE_ROLE_LEAVE = r"""
 Member {user_name} has left the {project_label} "{project}".
 For them to regain access, it has to be granted again by {project_label}
 owner or delegate.
-'''.lstrip()
+""".lstrip()
 
 
 # Invite Template --------------------------------------------------------------
@@ -118,7 +118,7 @@ owner or delegate.
 
 SUBJECT_INVITE = 'Invitation for {project_label} "{project}"'
 
-MESSAGE_INVITE_BODY = r'''
+MESSAGE_INVITE_BODY = r"""
 You have been invited by {issuer}
 to share data in the {project_label} "{project}" with the
 role of "{role}".
@@ -132,14 +132,14 @@ accepting the invitation, please access the project with its URL or
 through the project list on the site's "Home" page.
 
 This invitation will expire on {date_expire}.
-'''
+"""
 
-MESSAGE_INVITE_ISSUER = r'''
+MESSAGE_INVITE_ISSUER = r"""
 Message from the sender of this invitation:
 ----------------------------------------
 {}
 ----------------------------------------
-'''
+"""
 
 
 # Invite Acceptance Notification Template --------------------------------------
@@ -147,11 +147,11 @@ Message from the sender of this invitation:
 
 SUBJECT_ACCEPT = 'Invitation accepted by {user} for {project_label} "{project}"'
 
-MESSAGE_ACCEPT_BODY = r'''
+MESSAGE_ACCEPT_BODY = r"""
 Invitation sent by you for role of "{role}" in {project_label} "{project}"
 has been accepted by {user}.
 They have been granted access in the {project_label} accordingly.
-'''.lstrip()
+""".lstrip()
 
 
 # Invite Expiry Notification Template ------------------------------------------
@@ -159,7 +159,7 @@ They have been granted access in the {project_label} accordingly.
 
 SUBJECT_EXPIRY = 'Expired invitation used by {user_name} in "{project}"'
 
-MESSAGE_EXPIRY_BODY = r'''
+MESSAGE_EXPIRY_BODY = r"""
 Invitation sent by you for role of "{role}" in {project_label} "{project}"
 was attempted to be used by {user_name} ({user_email}).
 
@@ -168,7 +168,7 @@ access was not granted to the user.
 
 Please add the role manually with "Add Member", if you still wish
 to grant the user access to the {project_label}.
-'''.lstrip()
+""".lstrip()
 
 
 # Project/Category Creation Notification Template ------------------------------
@@ -176,7 +176,7 @@ to grant the user access to the {project_label}.
 
 SUBJECT_PROJECT_CREATE = '{project_type} "{project}" created by {user}'
 
-MESSAGE_PROJECT_CREATE_BODY = r'''
+MESSAGE_PROJECT_CREATE_BODY = r"""
 {user} has created a new {project_type}
 under "{category}".
 You are receiving this email because you are the owner of the parent category.
@@ -187,7 +187,7 @@ Owner: {owner}
 
 You can access the project at the following link:
 {project_url}
-'''.lstrip()
+""".lstrip()
 
 
 # Project/Category Moving Notification Template ------------------------------
@@ -195,7 +195,7 @@ You can access the project at the following link:
 
 SUBJECT_PROJECT_MOVE = '{project_type} "{project}" moved by {user}'
 
-MESSAGE_PROJECT_MOVE_BODY = r'''
+MESSAGE_PROJECT_MOVE_BODY = r"""
 {user} has moved the {project_type} "{project}"
 under "{category}".
 You are receiving this email because you are the owner of the parent category.
@@ -206,7 +206,7 @@ Owner: {owner}
 
 You can access the project at the following link:
 {project_url}
-'''.lstrip()
+""".lstrip()
 
 
 # Project Archiving Template ---------------------------------------------------
@@ -214,7 +214,7 @@ You can access the project at the following link:
 
 SUBJECT_PROJECT_ARCHIVE = '{project_label_title} "{project}" archived by {user}'
 
-MESSAGE_PROJECT_ARCHIVE = r'''
+MESSAGE_PROJECT_ARCHIVE = r"""
 {user} has archived "{project}".
 The {project_label} is now read-only. Modifying data in
 {project_label} apps has been disabled. Existing project data
@@ -222,7 +222,7 @@ can still be accessed and user roles can be modified.
 
 You can access the archived {project_label} at the following link:
 {project_url}
-'''.lstrip()
+""".lstrip()
 
 
 # Project Unarchiving Template -------------------------------------------------
@@ -232,25 +232,25 @@ SUBJECT_PROJECT_UNARCHIVE = (
     '{project_label_title} "{project}" unarchived by {user}'
 )
 
-MESSAGE_PROJECT_UNARCHIVE = r'''
+MESSAGE_PROJECT_UNARCHIVE = r"""
 {user} has unarchived "{project}".
 {project_label_title} data can now be modified and write
 access for users has been restored.
 
 You can access the {project_label} at the following link:
 {project_url}
-'''.lstrip()
+""".lstrip()
 
 
 # Project Deletion Template ----------------------------------------------------
 
 SUBJECT_PROJECT_DELETE = '{project_label_title} "{project}" deleted by {user}'
 
-MESSAGE_PROJECT_DELETE = r'''
+MESSAGE_PROJECT_DELETE = r"""
 {user} has deleted "{project}".
 The {project_label} has been removed from the site and can no
 longer be accessed.
-'''.lstrip()
+""".lstrip()
 
 
 # Email composing helpers ------------------------------------------------------

--- a/projectroles/forms.py
+++ b/projectroles/forms.py
@@ -746,8 +746,8 @@ class ProjectForm(SODARAppSettingFormMixin, SODARModelForm):
                 self.initial['owner'] = parent_cat.get_owner().user
             else:
                 self.initial['owner'] = self.current_user
-            self.fields['owner'].label_from_instance = (
-                lambda x: x.get_form_label(email=True)
+            self.fields['owner'].label_from_instance = lambda x: (
+                x.get_form_label(email=True)
             )
             # Hide owner select widget for regular users
             if not self.current_user.is_superuser:
@@ -1106,7 +1106,7 @@ class RoleAssignmentOwnerTransferForm(SODARForm):
         self.fields['old_owner_role'] = forms.ChoiceField(
             label=f'New role for {current_owner.username}',
             help_text='New role for the current owner. Select "Remove" in '
-            'the member list to remove the user\'s membership.',
+            "the member list to remove the user's membership.",
             choices=self.selectable_roles,
             initial=self.selectable_roles[0][0],
             disabled=True if len(self.selectable_roles) == 1 else False,
@@ -1151,7 +1151,7 @@ class RoleAssignmentOwnerTransferForm(SODARForm):
         user = self.cleaned_data['new_owner']
         if user == self.current_owner:
             raise forms.ValidationError(
-                'The new owner shouldn\'t be the current owner.'
+                "The new owner shouldn't be the current owner."
             )
         role_as = self.project.get_role(user)
         if not role_as:
@@ -1430,8 +1430,8 @@ class LocalUserForm(SODARModelForm):
     def clean(self):
         cleaned_data = super().clean()
         if cleaned_data['password'] != cleaned_data['password_confirm']:
-            self.add_error('password_confirm', 'Passwords didn\'t match!')
-            self.add_error('password', 'Passwords didn\'t match!')
+            self.add_error('password_confirm', "Passwords didn't match!")
+            self.add_error('password', "Passwords didn't match!")
         return cleaned_data
 
 

--- a/projectroles/management/commands/syncremote.py
+++ b/projectroles/management/commands/syncremote.py
@@ -28,8 +28,7 @@ class Command(BaseCommand):
         remote_api = RemoteProjectAPI()
         if getattr(settings, 'PROJECTROLES_DISABLE_CATEGORIES', False):
             logger.info(
-                'Project categories and nesting disabled, '
-                'remote sync disabled'
+                'Project categories and nesting disabled, remote sync disabled'
             )
             sys.exit(0)
         if settings.PROJECTROLES_SITE_MODE != SITE_MODE_TARGET:

--- a/projectroles/migrations/0001_squashed_0032_alter_appsetting_value.py
+++ b/projectroles/migrations/0001_squashed_0032_alter_appsetting_value.py
@@ -210,7 +210,6 @@ def populate_additional_email_model(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ('projectroles', '0001_initial'),
         ('projectroles', '0002_auto_20180411_1758'),

--- a/projectroles/migrations/0033_alter_sodaruseradditionalemail_secret.py
+++ b/projectroles/migrations/0033_alter_sodaruseradditionalemail_secret.py
@@ -4,17 +4,16 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ("projectroles", "0001_squashed_0032_alter_appsetting_value"),
+        ('projectroles', '0001_squashed_0032_alter_appsetting_value'),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name="sodaruseradditionalemail",
-            name="secret",
+            model_name='sodaruseradditionalemail',
+            name='secret',
             field=models.CharField(
-                help_text="Secret token for email verification",
+                help_text='Secret token for email verification',
                 max_length=255,
                 null=True,
                 unique=True,

--- a/projectroles/migrations/0034_fix_project_star.py
+++ b/projectroles/migrations/0034_fix_project_star.py
@@ -19,7 +19,6 @@ def fix_project_star(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('projectroles', '0033_alter_sodaruseradditionalemail_secret'),
     ]

--- a/projectroles/migrations/0035_populate_viewer_role.py
+++ b/projectroles/migrations/0035_populate_viewer_role.py
@@ -27,7 +27,6 @@ def revert_viewer_role(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('projectroles', '0034_fix_project_star'),
     ]

--- a/projectroles/migrations/0036_project_public_access.py
+++ b/projectroles/migrations/0036_project_public_access.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('projectroles', '0035_populate_viewer_role'),
     ]

--- a/projectroles/migrations/0037_populate_public_access.py
+++ b/projectroles/migrations/0037_populate_public_access.py
@@ -28,7 +28,6 @@ def revert_public_access(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('projectroles', '0036_project_public_access'),
     ]

--- a/projectroles/migrations/0038_update_ip_allow_list.py
+++ b/projectroles/migrations/0038_update_ip_allow_list.py
@@ -28,7 +28,6 @@ def update_ip_allow_list(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('projectroles', '0037_populate_public_access'),
     ]

--- a/projectroles/migrations/0039_remove_project_public_guest_access.py
+++ b/projectroles/migrations/0039_remove_project_public_guest_access.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('projectroles', '0038_update_ip_allow_list'),
     ]

--- a/projectroles/migrations/0040_remove_appsetting_user_modifiable.py
+++ b/projectroles/migrations/0040_remove_appsetting_user_modifiable.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('projectroles', '0039_remove_project_public_guest_access'),
     ]

--- a/projectroles/migrations/0041_alter_appsetting_unique_together_and_more.py
+++ b/projectroles/migrations/0041_alter_appsetting_unique_together_and_more.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('djangoplugins', '0002_auto_20230718_1254'),
         ('projectroles', '0040_remove_appsetting_user_modifiable'),

--- a/projectroles/migrations/0042_remove_project__readme_rendered_and_more.py
+++ b/projectroles/migrations/0042_remove_project__readme_rendered_and_more.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('projectroles', '0041_alter_appsetting_unique_together_and_more'),
     ]

--- a/projectroles/models.py
+++ b/projectroles/models.py
@@ -70,7 +70,7 @@ PROJECT_TAG_STARRED = 'STARRED'
 CAT_DELIMITER = ' / '
 CAT_DELIMITER_ERROR_MSG = f'String "{CAT_DELIMITER}" is not allowed in title'
 ROLE_PROJECT_TYPE_ERROR_MSG = (
-    'Invalid project type "{project_type}" for ' 'role "{role_name}"'
+    'Invalid project type "{project_type}" for role "{role_name}"'
 )
 CAT_PUBLIC_ACCESS_MSG = 'Public access is not allowed for categories'
 ADD_EMAIL_ALREADY_SET_MSG = 'Email already set as {email_type} email for user'

--- a/projectroles/plugins.py
+++ b/projectroles/plugins.py
@@ -641,14 +641,14 @@ class SiteAppPluginPoint(PluginPoint):
         :param user: User object (optional)
         :return: List of dicts or and empty list if no messages
         """
-        '''
+        """
         Example of valid return data:
         return [{
             'content': 'Message content in here, can contain html',
             'color': 'info',        # Corresponds to bg-* in Bootstrap
             'dismissable': True     # False for non-dismissable
         }]
-        '''
+        """
         return []
 
     def get_object(self, model: type[Model], uuid: Union[str, UUID]) -> Any:

--- a/projectroles/remote_projects.py
+++ b/projectroles/remote_projects.py
@@ -696,8 +696,9 @@ class RemoteProjectAPI:
             self.remote_data['projects'][uuid]['status'] = 'updated'
             if self.tl_user:  # Timeline
                 tl_desc = (
-                    'update project from remote site '
-                    '"{{{}}}" ({})'.format('site', ', '.join(updated_fields))
+                    'update project from remote site "{{{}}}" ({})'.format(
+                        'site', ', '.join(updated_fields)
+                    )
                 )
                 # TODO: Add extra_data
                 tl_event = self.timeline.add_event(
@@ -873,9 +874,9 @@ class RemoteProjectAPI:
                         r['user'], self.default_owner.username
                     )
                 )
-                self.remote_data['projects'][uuid]['roles'][r_uuid][
-                    'user'
-                ] = self.default_owner.username
+                self.remote_data['projects'][uuid]['roles'][r_uuid]['user'] = (
+                    self.default_owner.username
+                )
                 self.remote_data['projects'][uuid]['roles'][r_uuid][
                     'status_msg'
                 ] = status_msg
@@ -943,8 +944,9 @@ class RemoteProjectAPI:
 
                 if self.tl_user:
                     tl_desc = (
-                        'add role "{}" for {{{}}} '
-                        'from site {{{}}}'.format(role.name, 'user', 'site')
+                        'add role "{}" for {{{}}} from site {{{}}}'.format(
+                            role.name, 'user', 'site'
+                        )
                     )
                     tl_event = self.timeline.add_event(
                         project=project,
@@ -995,8 +997,9 @@ class RemoteProjectAPI:
                 }
                 if self.tl_user:  # Timeline
                     tl_desc = (
-                        'remove role "{}" from {{{}}} by site '
-                        '{{{}}}'.format(del_role.name, 'user', 'site')
+                        'remove role "{}" from {{{}}} by site {{{}}}'.format(
+                            del_role.name, 'user', 'site'
+                        )
                     )
                     tl_event = timeline.add_event(
                         project=project,
@@ -1213,8 +1216,10 @@ class RemoteProjectAPI:
             app_plugin = Plugin.objects.filter(name=ad['app_plugin']).first()
             if not app_plugin:
                 logger.debug(
-                    skip_msg + 'App plugin not found with name '
-                    '"{}"'.format(ad['app_plugin'])
+                    skip_msg
+                    + 'App plugin not found with name "{}"'.format(
+                        ad['app_plugin']
+                    )
                 )
                 return
         if user_name:

--- a/projectroles/serializers.py
+++ b/projectroles/serializers.py
@@ -471,7 +471,7 @@ class ProjectSerializer(ProjectModifyMixin, SODARModelSerializer):
         ):
             raise serializers.ValidationError(CAT_DELIMITER_ERROR_MSG)
         if parent and title == parent.title:
-            raise serializers.ValidationError('Title can\'t match with parent')
+            raise serializers.ValidationError("Title can't match with parent")
         if (
             title
             and not self.instance

--- a/projectroles/templatetags/projectroles_common_tags.py
+++ b/projectroles/templatetags/projectroles_common_tags.py
@@ -211,8 +211,7 @@ def get_user_superuser_icon(tooltip: bool = True) -> str:
     if tooltip:
         ret += '<span title="Superuser" data-toggle="tooltip">'
     ret += (
-        '<i class="iconify text-info ml-1" '
-        'data-icon="mdi:shield-account"></i>'
+        '<i class="iconify text-info ml-1" data-icon="mdi:shield-account"></i>'
     )
     if tooltip:
         ret += '</span>'

--- a/projectroles/templatetags/projectroles_tags.py
+++ b/projectroles/templatetags/projectroles_tags.py
@@ -179,8 +179,9 @@ def get_login_info() -> str:
         ):
             ret += ' or ' + settings.AUTH_LDAP2_DOMAIN_PRINTABLE
         ret += (
-            ' account. Enter your user name as <code>username@{}'
-            '</code>'.format(getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN', ''))
+            ' account. Enter your user name as <code>username@{}</code>'.format(
+                getattr(settings, 'AUTH_LDAP_USERNAME_DOMAIN', '')
+            )
         )
         if (
             settings.ENABLE_LDAP_SECONDARY

--- a/projectroles/tests/test_app_settings.py
+++ b/projectroles/tests/test_app_settings.py
@@ -358,7 +358,7 @@ class TestAppSettingAPI(
         with self.assertRaises(ValueError):
             app_settings.get(
                 EXAMPLE_APP_NAME,
-                "project_int_setting",
+                'project_int_setting',
                 project=None,  # No project
                 user=self.user,
             )
@@ -368,7 +368,7 @@ class TestAppSettingAPI(
         with self.assertRaises(ValueError):
             app_settings.get(
                 EXAMPLE_APP_NAME,
-                "user_str_setting",
+                'user_str_setting',
                 project=self.project,
                 user=None,  # No user
             )
@@ -378,7 +378,7 @@ class TestAppSettingAPI(
         with self.assertRaises(ValueError):
             app_settings.get(
                 EXAMPLE_APP_NAME,
-                "project_user_bool_setting",
+                'project_user_bool_setting',
                 project=self.project,
                 user=None,  # No user
             )
@@ -388,7 +388,7 @@ class TestAppSettingAPI(
         with self.assertRaises(ValueError):
             app_settings.get(
                 EXAMPLE_APP_NAME,
-                "site_bool_setting",
+                'site_bool_setting',
                 project=self.project,  # Project is passed when it shouldn't be
                 user=None,
             )
@@ -485,7 +485,8 @@ class TestAppSettingAPI(
         """Test get_all_by_scope() with invalid args"""
         with self.assertRaises(ValueError):
             app_settings.get_all_by_scope(
-                APP_SETTING_SCOPE_PROJECT_USER, project=self.project  # No user
+                APP_SETTING_SCOPE_PROJECT_USER,
+                project=self.project,  # No user
             )
 
     def test_is_set_no_object(self):

--- a/projectroles/tests/test_models.py
+++ b/projectroles/tests/test_models.py
@@ -397,7 +397,7 @@ class TestProject(ProjectMixin, RoleMixin, RoleAssignmentMixin, TestCase):
 
     def test__repr__(self):
         """Test Project __repr__()"""
-        expected = "Project('TestProject', 'PROJECT', " "'TestCategory')"
+        expected = "Project('TestProject', 'PROJECT', 'TestCategory')"
         self.assertEqual(repr(self.project), expected)
 
     def test_validate_parent(self):
@@ -1014,7 +1014,7 @@ class TestProjectInvite(
     def test__str__(self):
         """Test ProjectInvite __str__()"""
         expected = (
-            'TestProject: test@example.com (project contributor) ' '[ACTIVE]'
+            'TestProject: test@example.com (project contributor) [ACTIVE]'
         )
         self.assertEqual(str(self.invite), expected)
 
@@ -1989,8 +1989,8 @@ class TestSODARUserAdditionalEmail(SODARUserAdditionalEmailMixin, TestCase):
 
     def test__repr__(self):
         """Test SODARUserAdditionalEmail __repr__()"""
-        expected = 'SODARUserAdditionalEmail(\'{}\')'.format(
-            '\', \''.join(
+        expected = "SODARUserAdditionalEmail('{}')".format(
+            "', '".join(
                 [
                     self.email.user.username,
                     self.email.email,

--- a/projectroles/tests/test_remote_project_api.py
+++ b/projectroles/tests/test_remote_project_api.py
@@ -1400,9 +1400,9 @@ class TestSyncRemoteDataCreate(SyncRemoteDataTestBase):
     def test_create_app_setting_local(self):
         """Test sync with local app setting"""
         self.remote_data['app_settings'][SET_IP_RESTRICT_UUID]['global'] = False
-        self.remote_data['app_settings'][SET_IP_ALLOW_LIST_UUID][
-            'global'
-        ] = False
+        self.remote_data['app_settings'][SET_IP_ALLOW_LIST_UUID]['global'] = (
+            False
+        )
         expected = deepcopy(self.remote_data)
         self.remote_api.sync_remote_data(self.source_site, self.remote_data)
 
@@ -1584,12 +1584,12 @@ class TestSyncRemoteDataCreate(SyncRemoteDataTestBase):
 
     def test_create_no_access(self):
         """Test sync with no READ_ROLE access set"""
-        self.remote_data['projects'][SOURCE_CATEGORY_UUID][
-            'level'
-        ] = REMOTE_LEVEL_READ_INFO
-        self.remote_data['projects'][SOURCE_PROJECT_UUID][
-            'level'
-        ] = REMOTE_LEVEL_READ_INFO
+        self.remote_data['projects'][SOURCE_CATEGORY_UUID]['level'] = (
+            REMOTE_LEVEL_READ_INFO
+        )
+        self.remote_data['projects'][SOURCE_PROJECT_UUID]['level'] = (
+            REMOTE_LEVEL_READ_INFO
+        )
         expected = deepcopy(self.remote_data)
         self.remote_api.sync_remote_data(self.source_site, self.remote_data)
 
@@ -1882,17 +1882,17 @@ class TestSyncRemoteDataUpdate(
 
         # Change Peer Site data
         self.remote_data['peer_sites'][PEER_SITE_UUID]['name'] = NEW_PEER_NAME
-        self.remote_data['peer_sites'][PEER_SITE_UUID][
-            'description'
-        ] = NEW_PEER_DESC
-        self.remote_data['peer_sites'][PEER_SITE_UUID][
-            'user_display'
-        ] = NEW_PEER_USER_DISPLAY
+        self.remote_data['peer_sites'][PEER_SITE_UUID]['description'] = (
+            NEW_PEER_DESC
+        )
+        self.remote_data['peer_sites'][PEER_SITE_UUID]['user_display'] = (
+            NEW_PEER_USER_DISPLAY
+        )
         # Change projectroles app settings
         self.remote_data['app_settings'][SET_IP_RESTRICT_UUID]['value'] = True
-        self.remote_data['app_settings'][SET_IP_ALLOW_LIST_UUID][
-            'value'
-        ] = '192.168.1.1'
+        self.remote_data['app_settings'][SET_IP_ALLOW_LIST_UUID]['value'] = (
+            '192.168.1.1'
+        )
         self.remote_data['projects'][SOURCE_CATEGORY_UUID]['status'] = 'updated'
         self.remote_data['projects'][SOURCE_PROJECT_UUID]['status'] = 'updated'
         self.remote_data['users'][SOURCE_USER_UUID]['status'] = 'updated'
@@ -2256,9 +2256,9 @@ class TestSyncRemoteDataUpdate(
             'status'
         ] = 'created'
         expected['app_settings'][SET_IP_RESTRICT_UUID]['value'] = True
-        expected['app_settings'][SET_IP_ALLOW_LIST_UUID][
-            'value'
-        ] = '192.168.1.1'
+        expected['app_settings'][SET_IP_ALLOW_LIST_UUID]['value'] = (
+            '192.168.1.1'
+        )
         expected['app_settings'][SET_IP_RESTRICT_UUID]['status'] = 'updated'
         expected['app_settings'][SET_IP_ALLOW_LIST_UUID]['status'] = 'updated'
         expected['app_settings'][SET_STAR_UUID]['status'] = 'skipped'
@@ -2365,9 +2365,9 @@ class TestSyncRemoteDataUpdate(
     def test_update_settings_local(self):
         """Test update with local app settings (should not be updated)"""
         self.remote_data['app_settings'][SET_IP_RESTRICT_UUID]['global'] = False
-        self.remote_data['app_settings'][SET_IP_ALLOW_LIST_UUID][
-            'global'
-        ] = False
+        self.remote_data['app_settings'][SET_IP_ALLOW_LIST_UUID]['global'] = (
+            False
+        )
         self.remote_data['app_settings'][SET_IP_RESTRICT_UUID]['value'] = True
         self.remote_data['app_settings'][SET_IP_ALLOW_LIST_UUID][
             'value_json'
@@ -2516,9 +2516,9 @@ class TestSyncRemoteDataUpdate(
         self.assertEqual(RemoteSite.objects.all().count(), 2)
 
         # Revoke access to project
-        self.remote_data['projects'][SOURCE_PROJECT_UUID][
-            'level'
-        ] = REMOTE_LEVEL_REVOKED
+        self.remote_data['projects'][SOURCE_PROJECT_UUID]['level'] = (
+            REMOTE_LEVEL_REVOKED
+        )
         self.remote_data['projects'][SOURCE_PROJECT_UUID]['remote_sites'] = []
         self.remote_api.sync_remote_data(self.source_site, self.remote_data)
 

--- a/projectroles/tests/test_templatetags.py
+++ b/projectroles/tests/test_templatetags.py
@@ -633,12 +633,12 @@ class TestProjectrolesCommonTags(TemplateTagTestBase):
         # TODO: Replace with get_app_plugin once implemented for backend plugins
         backend_plugin = plugin_api.get_active_plugins('backend')[0]
 
-        type(backend_plugin).javascript_url = (
-            'example_backend_app/js/NOT_EXISTING_JS.js'
-        )
-        type(backend_plugin).css_url = (
-            'example_backend_app/css/NOT_EXISTING_CSS.css'
-        )
+        type(
+            backend_plugin
+        ).javascript_url = 'example_backend_app/js/NOT_EXISTING_JS.js'
+        type(
+            backend_plugin
+        ).css_url = 'example_backend_app/css/NOT_EXISTING_CSS.css'
 
         self.assertEqual(
             c_tags.get_backend_include(backend_plugin.name, 'js'), ''
@@ -652,9 +652,9 @@ class TestProjectrolesCommonTags(TemplateTagTestBase):
         # TODO: Replace with get_app_plugin once implemented for backend plugins
         backend_plugin = plugin_api.get_active_plugins('backend')[0]
 
-        type(backend_plugin).javascript_url = (
-            'example_backend_app/js/greeting.js'
-        )
+        type(
+            backend_plugin
+        ).javascript_url = 'example_backend_app/js/greeting.js'
         type(backend_plugin).css_url = 'example_backend_app/css/greeting.css'
 
         self.assertEqual(

--- a/projectroles/tests/test_ui.py
+++ b/projectroles/tests/test_ui.py
@@ -411,14 +411,16 @@ class TestHomeView(ProjectUITestBase):
             ),
             False,
         )
-        app_settings.set(
-            plugin_name=APP_NAME,
-            setting_name='project_star',
-            value=True,
-            project=self.project,
-            user=self.user_owner,
-            validate=False,
-        ),
+        (
+            app_settings.set(
+                plugin_name=APP_NAME,
+                setting_name='project_star',
+                value=True,
+                project=self.project,
+                user=self.user_owner,
+                validate=False,
+            ),
+        )
         self.login_and_redirect(self.user_owner, self.url, **self.wait_kwargs)
         self.assertEqual(self._get_item_vis_count(), 2)
         button = self.selenium.find_element(
@@ -446,14 +448,16 @@ class TestHomeView(ProjectUITestBase):
 
     def test_project_list_filter_star(self):
         """Test toggling star with filter enabled"""
-        app_settings.set(
-            plugin_name=APP_NAME,
-            setting_name='project_star',
-            value=True,
-            project=self.category,
-            user=self.user_owner,
-            validate=False,
-        ),
+        (
+            app_settings.set(
+                plugin_name=APP_NAME,
+                setting_name='project_star',
+                value=True,
+                project=self.category,
+                user=self.user_owner,
+                validate=False,
+            ),
+        )
         self.login_and_redirect(self.user_owner, self.url, **self.wait_kwargs)
         self.assertEqual(self._get_item_vis_count(), 2)
         f_input = self.selenium.find_element(

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -2118,10 +2118,11 @@ class ProjectRoleView(
             [r.role.rank >= owner_rank for r in context['roles']]
         )
         if project.is_remote():
-            context[
-                'remote_roles_url'
-            ] = project.get_source_site().url + reverse(
-                'projectroles:roles', kwargs={'project': project.sodar_uuid}
+            context['remote_roles_url'] = (
+                project.get_source_site().url
+                + reverse(
+                    'projectroles:roles', kwargs={'project': project.sodar_uuid}
+                )
             )
         context['finder_info'] = ROLE_FINDER_INFO.format(
             categories=get_display_name(PROJECT_TYPE_CATEGORY, plural=True),
@@ -3827,8 +3828,7 @@ class RemoteSiteListView(
         if getattr(settings, 'PROJECTROLES_DISABLE_CATEGORIES', False):
             messages.warning(
                 request,
-                '{} {} and nesting disabled, '
-                'remote {} sync disabled.'.format(
+                '{} {} and nesting disabled, remote {} sync disabled.'.format(
                     get_display_name(PROJECT_TYPE_PROJECT, title=True),
                     get_display_name(PROJECT_TYPE_CATEGORY, plural=True),
                     get_display_name(PROJECT_TYPE_PROJECT),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,25 @@ exclude = [
 [tool.ruff.format]
 quote-style = "single"
 
+[tool.ruff.lint]
+exclude = [
+    ".git",
+    "*/migrations/*",
+    "*/static/CACHE/*",
+    "docs",
+    "node_modules",
+    "config/*",
+    "versioneer.py",
+    "env/*",
+    ".venv",
+    "_version.py"
+]
+ignore = ["E203", "E266", "E501", "F405"]
+# TODO: Add B and Q, tweak ignores, fix warnings
+select = ["E", "F", "W"]
+
 [tool.ruff.lint.flake8-quotes]
 inline-quotes = "single"
+
+[tool.ruff.lint.mccabe]
+max-complexity = 18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ exclude = [
     "src",
     "docs",
     "versioneer.py",
+    "_version.py"
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,22 @@
 requires = ["setuptools>=80.9.0", "versioneer[toml]==0.29"]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
+[tool.ruff]
 line-length = 80
-skip-string-normalization = true
-exclude = ".git|.venv|.tox|build|env|src|docs|versioneer.py"
+indent-width = 4
+exclude = [
+    ".git",
+    ".venv",
+    ".tox",
+    "build",
+    "env",
+    "src",
+    "docs",
+    "versioneer.py",
+]
+
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.ruff.lint.flake8-quotes]
+docstring-quotes = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ exclude = [
 quote-style = "single"
 
 [tool.ruff.lint.flake8-quotes]
-docstring-quotes = "double"
+inline-quotes = "single"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,6 @@
 # Test dependencies go here.
 -r base.txt
 
-flake8==7.3.0
 django-test-plus==2.3.0
 factory-boy==3.3.3
 coverage==7.11.0
@@ -20,12 +19,8 @@ tblib==3.2.0
 # BeautifulSoup for HTML testing
 beautifulsoup4==4.14.2
 
-# Ruff for linting and formatting (replaces black)
+# Ruff for linting and formatting (replaces black and flake8)
 ruff==0.15.6
-
-# Black for formatting
-# TODO: Remove once Ruff integration is done
-black==25.9.0
 
 # JQuery beautifying
 jsbeautifier==1.15.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,7 +20,11 @@ tblib==3.2.0
 # BeautifulSoup for HTML testing
 beautifulsoup4==4.14.2
 
+# Ruff for linting and formatting (replaces black)
+ruff==0.15.6
+
 # Black for formatting
+# TODO: Remove once Ruff integration is done
 black==25.9.0
 
 # JQuery beautifying

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[flake8]
-max-line-length = 80
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,src/*,
-          config/*,versioneer.py,env/*,.venv,_version.py
-ignore = E203, E266, E501, W503, W504
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-
-[pycodestyle]
-max-line-length = 80
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,src/*,
-          config/*,versioneer.py,env/*
-
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 """
 Package metadata for django-sodar-core.
 """
+
 import os
 from setuptools import setup
 

--- a/siteinfo/tests/test_ui.py
+++ b/siteinfo/tests/test_ui.py
@@ -102,7 +102,7 @@ class TestSiteInfoUI(UITestBase):
 
         self.login_and_redirect(self.superuser, self.url)
         parent_card_element = (
-            '//div[@id="nav-general"]' '//div[@data-plugin-name="adminalerts"]'
+            '//div[@id="nav-general"]//div[@data-plugin-name="adminalerts"]'
         )
         WebDriverWait(self.selenium, self.wait_time).until(
             ec.visibility_of_element_located((By.XPATH, parent_card_element))

--- a/sodarcache/migrations/0001_squashed_0004_update_jsonfield.py
+++ b/sodarcache/migrations/0001_squashed_0004_update_jsonfield.py
@@ -7,7 +7,6 @@ import uuid
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ('sodarcache', '0001_initial'),
         ('sodarcache', '0002_make_user_optional'),

--- a/sodarcache/migrations/0005_alter_jsoncacheitem_unique_together_and_more.py
+++ b/sodarcache/migrations/0005_alter_jsoncacheitem_unique_together_and_more.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('projectroles', '0041_alter_appsetting_unique_together_and_more'),
         ('sodarcache', '0001_squashed_0004_update_jsonfield'),

--- a/timeline/api.py
+++ b/timeline/api.py
@@ -336,7 +336,7 @@ class TimelineAPI:
         :return: String (contains HTML)
         """
         desc = event.description
-        ref_ids = re.findall('{\'?(.*?)\'?}', desc)
+        ref_ids = re.findall("{'?(.*?)'?}", desc)
         if len(ref_ids) == 0:
             return event.description
         refs = {}

--- a/timeline/migrations/0001_squashed_0015_make_uuid_unique.py
+++ b/timeline/migrations/0001_squashed_0015_make_uuid_unique.py
@@ -32,7 +32,6 @@ def populate_object_ref_uuid(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ('timeline', '0001_initial'),
         ('timeline', '0002_projectevent_user'),

--- a/tokens/migrations/0001_rename_plugin.py
+++ b/tokens/migrations/0001_rename_plugin.py
@@ -12,7 +12,6 @@ def rename_plugin(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = []
 
     operations = [

--- a/tokens/migrations/0002_delete_legacy_tokens.py
+++ b/tokens/migrations/0002_delete_legacy_tokens.py
@@ -14,7 +14,6 @@ def delete_legacy_tokens(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('tokens', '0001_rename_plugin'),
     ]

--- a/tokens/migrations/0003_add_sodarauthmodel.py
+++ b/tokens/migrations/0003_add_sodarauthmodel.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/userprofile/tests/test_views.py
+++ b/userprofile/tests/test_views.py
@@ -309,7 +309,7 @@ class TestUserAppSettingsView(AppSettingMixin, UserViewTestBase):
     def test_post_custom_validation(self):
         """Test POST with custom validation and invalid value"""
         values = {
-            'settings.example_project_app.' 'user_str_setting': INVALID_VALUE,
+            'settings.example_project_app.user_str_setting': INVALID_VALUE,
             'settings.example_project_app.user_int_setting': '170',
             'settings.example_project_app.user_str_setting_options': 'string1',
             'settings.example_project_app.user_int_setting_options': '0',

--- a/userprofile/views.py
+++ b/userprofile/views.py
@@ -42,7 +42,7 @@ APP_NAME = 'userprofile'
 APP_NAME_PR = 'projectroles'
 SETTING_UPDATE_MSG = 'User settings updated.'
 VERIFY_EMAIL_SUBJECT = 'Verify your additional email address for {site}'
-VERIFY_EMAIL_BODY = r'''
+VERIFY_EMAIL_BODY = r"""
 {user} has added this address to their
 additional emails on {site}.
 
@@ -53,7 +53,7 @@ Please verify this email address by following this URL:
 {url}
 
 If this was not requested by you, this message can be ignored.
-'''.lstrip()
+""".lstrip()
 EMAIL_NOT_FOUND_MSG = 'No email found.'
 EMAIL_ALREADY_VERIFIED_MSG = 'Email already verified.'
 EMAIL_VERIFIED_MSG = 'Email "{email}" verified.'

--- a/utility/get_chromedriver_url.py
+++ b/utility/get_chromedriver_url.py
@@ -34,5 +34,5 @@ def main():
     )
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
Setting up Ruff to replace Black and Flake8 for formatting and linting. This intends to handle #1881.

I did the following:

- Replace dependencies
- Set up configuration for linting and formatting in `pyproject.toml`
- Reorganize `Makefile` with separate commands for linting, formatting and checking
    * These don't have to be used, but it provides a consistent interface if e.g. a better option than Ruff emerges in the future :)
- Update CI workflows
- Update docs

**Note:** At the time of writing, reformatting the code has **NOT** yet been done in this work branch. I'll do that once I'm ready to merge, in order to avoid unnecessary merge conflicts with other ongoing PRs. @fmarotta, let's discuss when would be the best time to do this :)