### PR TITLE
Replace search() "search_type" kwarg with "keywords" item and "keywords" kwarg with **kwargs

### DIFF
--- a/docs/source/dev_project_app.rst
+++ b/docs/source/dev_project_app.rst
@@ -634,18 +634,20 @@ See the signature of ``search()`` in
 ``projects``
     - ``QuerySet`` of Project objects within which the search should be
       restricted.
-``search_type``
+``**kwargs``
+    - Special search options as additional key-value pairs.
+
+Currently we support two keyword arguments:
+``project``
+    - Used to limit the search to a specific project or category.
+    - The full list of projects is pre-fetched for efficiency and passed in
+      the ``projects`` argument, but apps can optionally also make use of the
+      original user-provided UUID or title.
+``type``
     - The type of object to search for (string, optional).
     - Used to restrict search to specific types of objects.
     - You can specify supported types in the plugin's ``search_types`` list.
     - Examples: ``file``, ``sample``..
-``keywords``
-    - Special search keywords as a dictionary of ``key:value`` pairs.
-    - Currently the only supported keyword is ``project``, which is used to
-      limit the search to a specific project or category. The full list of
-      projects is pre-fetched for efficiency and passed in the ``projects``
-      argument, but apps can optionally also make use of the original
-      user-provided UUID or title.
 
 .. note::
 

--- a/docs/source/major_changes.rst
+++ b/docs/source/major_changes.rst
@@ -42,14 +42,20 @@ Plugin API search() Changes
 ---------------------------
 
 The signature of the ``search()`` function implemented by plugins has changed:
-it now takes an extra positional argument, ``projects``, which contains a
-``QuerySet`` of projects within which the search should be restricted. All
-SODAR Core apps are expected to honor this filtering criterion. Furthermore,
-the ``keywords`` dictionary (passed to ``search()`` as a kwarg) can contain a
-``project:<uuid or title>`` key-value pair which identifies the user-provided
-project or category where the search is restricted. The projects are pre-fetched
-for efficiency and passed to ``search()`` through the ``projects`` argument, but
-apps can optionally also make use of the original UUID or title.
+- It now takes a new positional argument, ``projects``, which contains a
+  ``QuerySet`` of projects within which the search should be restricted. All
+  SODAR Core apps are expected to honor this filtering criterion.
+- The ``search_type`` positional argument has been dropped in favour of the
+  ``type`` kwarg (see below)
+- The ``keywords`` dictionary has been replaced by the more general ``**kwargs``
+- Currently there are two supported keys for ``**kwargs``:
+    - ``project:<uuid or title>``, which identifies the user-provided project or
+      category where the search is restricted. The projects are pre-fetched
+      for efficiency and passed to ``search()`` through the ``projects``
+      argument, but apps can optionally also make use of the original UUID or
+      title.
+    - ``type:<string>``, which specifies the type of objects that should be
+      retrieved by the search.
 
 Previously Deprecated Features Removed
 --------------------------------------

--- a/filesfolders/plugins.py
+++ b/filesfolders/plugins.py
@@ -163,8 +163,7 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
         search_terms: list[str],
         user: User,
         projects: QuerySet[Project],
-        search_type: Optional[str] = None,
-        keywords: Optional[dict] = None,
+        **kwargs: str,
     ) -> list[PluginSearchResult]:
         """
         Return app items based on one or more search terms, user, optional type
@@ -174,28 +173,27 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
                              (list of strings)
         :param user: User object for user initiating the search
         :param projects: QuerySet of projects where the terms are searched
-        :param search_type: String
-        :param keywords: Dictionary of key/value pairs (optional)
+        :param kwargs: Search options as key/value pairs (optional)
         :return: List of PluginSearchResult objects
         """
         items = []
-        if not search_type:
-            files = File.objects.find(search_terms, projects, keywords)
-            folders = Folder.objects.find(search_terms, projects, keywords)
-            links = HyperLink.objects.find(search_terms, projects, keywords)
+        if 'type' not in kwargs:
+            files = File.objects.find(search_terms, projects, kwargs)
+            folders = Folder.objects.find(search_terms, projects, kwargs)
+            links = HyperLink.objects.find(search_terms, projects, kwargs)
             items = list(files) + list(folders) + list(links)
             items.sort(key=lambda x: x.name.lower())
-        elif search_type == 'file':
+        elif kwargs['type'] == 'file':
             items = File.objects.find(
-                search_terms, projects, keywords
+                search_terms, projects, kwargs
             ).order_by('name')
-        elif search_type == 'folder':
+        elif kwargs['type'] == 'folder':
             items = Folder.objects.find(
-                search_terms, projects, keywords
+                search_terms, projects, kwargs
             ).order_by('name')
-        elif search_type == 'link':
+        elif kwargs['type'] == 'link':
             items = HyperLink.objects.find(
-                search_terms, projects, keywords
+                search_terms, projects, kwargs
             ).order_by('name')
         if items:
             items = [

--- a/filesfolders/plugins.py
+++ b/filesfolders/plugins.py
@@ -184,9 +184,9 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
             items = list(files) + list(folders) + list(links)
             items.sort(key=lambda x: x.name.lower())
         elif kwargs['type'] == 'file':
-            items = File.objects.find(
-                search_terms, projects, kwargs
-            ).order_by('name')
+            items = File.objects.find(search_terms, projects, kwargs).order_by(
+                'name'
+            )
         elif kwargs['type'] == 'folder':
             items = Folder.objects.find(
                 search_terms, projects, kwargs

--- a/projectroles/templates/projectroles/search_results.html
+++ b/projectroles/templates/projectroles/search_results.html
@@ -10,8 +10,8 @@
     {% if search_terms|length == 1 %}
       for "{{ search_terms.0 }}"
     {% endif %}
-  {% if search_type %}
-    (type:{{ search_type }})
+  {% if 'type' in search_keywords %}
+    (type:{{ search_keywords.type }})
   {% endif %}
 {% endblock title %}
 
@@ -89,20 +89,20 @@
       {% else %}
         multiple terms
       {% endif %}
-      {% if search_type %}
-        (type:{{ search_type }})
+      {% if 'type' in search_keywords %}
+        (type:{{ search_keywords.type }})
       {% endif %}
     </div>
 </div>
 
 <div class="container-fluid sodar-page-container">
-  {% if search_type and search_type != 'project' and app_results|length == 0 %}
+  {% if 'type' in search_keywords and search_keywords.type != 'project' and app_results|length == 0 %}
     <div class="alert alert-danger" role="alert">
-      <strong>Error:</strong> Search type "{{ search_type }}" not recognized!
+      <strong>Error:</strong> Search type "{{ search_keywords.type }}" not recognized!
     </div>
   {% else %}
     {# Project Search #}
-    {% if not search_type or search_type == 'project' %}
+    {% if 'type' not in search_keywords or search_keywords.type == 'project' %}
       {% if project_results|length > 0 %}
         {% get_display_name 'PROJECT' title=True plural=True as projects_title %}
         {% include 'projectroles/_search_header.html' with search_title=projects_title result_count=project_results|length icon='mdi:cube' %}

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -432,7 +432,6 @@ class TestProjectSearchResultsView(
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['search_terms'], ['test'])
         self.assertEqual(response.context['search_keywords'], {})
-        self.assertEqual(response.context['search_type'], None)
         self.assertQuerySetEqual(
             response.context['search_projects'], Project.objects.all()
         )
@@ -473,11 +472,10 @@ class TestProjectSearchResultsView(
             )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['search_terms'], ['test'])
-        self.assertEqual(response.context['search_keywords'], {})
+        self.assertEqual(response.context['search_keywords'], {'type': 'file'})
         self.assertQuerySetEqual(
             response.context['search_projects'], Project.objects.all()
         )
-        self.assertEqual(response.context['search_type'], 'file')
         self.assertEqual(response.context['search_input'], 'test type:file')
         self.assertEqual(
             len(response.context['app_results']),
@@ -487,7 +485,7 @@ class TestProjectSearchResultsView(
                     for p in self.plugins
                     if (
                         p.search_enable
-                        and response.context['search_type'] in p.search_types
+                        and response.context['search_keywords'].get('type', None) in p.search_types
                     )
                 ]
             ),
@@ -660,7 +658,6 @@ class TestProjectSearchResultsView(
         self.assertQuerySetEqual(
             response.context['search_projects'], Project.objects.all()
         )
-        self.assertEqual(response.context['search_type'], None)
         self.assertEqual(response.context['search_input'], 'test project:')
 
     def test_get_non_text_input(self):
@@ -703,7 +700,6 @@ class TestProjectSearchResultsView(
             response.context['search_terms'], ['testproject', 'xxx']
         )
         self.assertEqual(response.context['search_keywords'], {})
-        self.assertEqual(response.context['search_type'], None)
         self.assertQuerySetEqual(
             response.context['search_projects'], Project.objects.all()
         )
@@ -727,7 +723,6 @@ class TestProjectSearchResultsView(
             response.context['search_keywords'],
             {'project': str(self.project2.sodar_uuid)},
         )
-        self.assertEqual(response.context['search_type'], None)
         # Only the project matching 'xxx' should be returned
         self.assertEqual(len(response.context['project_results']), 1)
 
@@ -748,7 +743,7 @@ class TestProjectSearchResultsView(
         )
         self.assertEqual(
             response.context['search_keywords'],
-            {'project': str(self.category.sodar_uuid)},
+            {'project': str(self.category.sodar_uuid), 'type': 'project'},
         )
         self.assertQuerySetEqual(
             response.context['search_projects'],
@@ -756,7 +751,6 @@ class TestProjectSearchResultsView(
                 full_title__startswith=self.category.full_title
             ),
         )
-        self.assertEqual(response.context['search_type'], 'project')
         self.assertEqual(len(response.context['project_results']), 2)
 
     def test_post_advanced_short_input(self):

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -452,7 +452,6 @@ class TestProjectSearchResultsView(
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['search_terms'], ['test quoted'])
         self.assertEqual(response.context['search_keywords'], {})
-        self.assertEqual(response.context['search_type'], None)
         self.assertQuerySetEqual(
             response.context['search_projects'], Project.objects.all()
         )
@@ -508,7 +507,6 @@ class TestProjectSearchResultsView(
             response.context['search_keywords'],
             {'project': str(self.project.sodar_uuid)},
         )
-        self.assertEqual(response.context['search_type'], None)
         self.assertQuerySetEqual(
             response.context['search_projects'],
             Project.objects.filter(sodar_uuid=self.project.sodar_uuid),
@@ -539,7 +537,6 @@ class TestProjectSearchResultsView(
             response.context['search_keywords'],
             {'project': 'white space'},
         )
-        self.assertEqual(response.context['search_type'], None)
         self.assertQuerySetEqual(
             response.context['search_projects'], Project.objects.none()
         )
@@ -566,7 +563,6 @@ class TestProjectSearchResultsView(
             response.context['search_keywords'],
             {'project': self.project.title.lower()},
         )
-        self.assertEqual(response.context['search_type'], None)
         self.assertQuerySetEqual(
             response.context['search_projects'],
             Project.objects.filter(title=self.project.title),
@@ -595,7 +591,6 @@ class TestProjectSearchResultsView(
             response.context['search_keywords'],
             {'project': self.category.title.lower()},
         )
-        self.assertEqual(response.context['search_type'], None)
         self.assertQuerySetEqual(
             response.context['search_projects'],
             Project.objects.filter(
@@ -634,7 +629,6 @@ class TestProjectSearchResultsView(
             response.context['search_keywords'],
             {'key1': 'value1', 'key2': 'value2 with spaces', 'key3': 'value3'},
         )
-        self.assertEqual(response.context['search_type'], None)
         self.assertEqual(
             response.context['search_input'],
             (
@@ -846,12 +840,8 @@ class TestProjectSearchResultsView(
             ['test with spaces', 'testproject', 'xxx'],
         )
         self.assertEqual(
-            response.context['search_type'],
-            'project',
-        )
-        self.assertEqual(
             response.context['search_keywords'],
-            {'project': 'project with spaces'},
+            {'project': 'project with spaces', 'type': 'project'},
         )
 
     def test_post_advanced_search_quoted_string_parsing(self):

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -485,7 +485,10 @@ class TestProjectSearchResultsView(
                     for p in self.plugins
                     if (
                         p.search_enable
-                        and response.context['search_keywords'].get('type', None) in p.search_types
+                        and response.context['search_keywords'].get(
+                            'type', None
+                        )
+                        in p.search_types
                     )
                 ]
             ),

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -733,14 +733,14 @@ class ProjectSearchMixin:
         user: User,
         search_terms: list[str],
         projects: QuerySet[Project],
-        search_type: Optional[str],
         search_keywords: Optional[dict],
     ) -> list:
         """
         Return app plugin search results.
 
+        :param user: user who initiated the sarch
         :param search_terms: Search terms (list of strings)
-        :param search_type: Optional type keyword for search (string or None)
+        :param projects: All projects where the search should be performed
         :param search_keywords: Optional keywords (dictionary or None)
         :return: List
         """
@@ -756,15 +756,16 @@ class ProjectSearchMixin:
             ],
             key=lambda x: x.plugin_ordering,
         )
-        if search_type:
+        if search_keywords and 'type' in search_keywords:
             search_apps = [
-                p for p in search_apps if search_type in p.search_types
+                p
+                for p in search_apps
+                if search_keywords['type'] in p.search_types
             ]
         for plugin in search_apps:
             search_kwargs = {
                 'user': user,
                 'projects': projects,
-                'search_type': search_type,
                 'search_terms': search_terms,
                 'keywords': search_keywords,
             }
@@ -861,7 +862,6 @@ class ProjectSearchResultsView(
         context = super().get_context_data(**kwargs)
         search_input = ''
         search_terms = []
-        search_type = None
         keyword_input = []
         search_keywords = {}
 
@@ -887,10 +887,7 @@ class ProjectSearchResultsView(
         for s in keyword_input:
             kw = s.split(':')[0].lower().strip()
             val = s.split(':')[1].lower().strip()
-            if kw == 'type':
-                search_type = val
-            else:
-                search_keywords[kw] = val
+            search_keywords[kw] = val
 
         if 'project' in search_keywords:
             try:
@@ -912,10 +909,9 @@ class ProjectSearchResultsView(
         context['search_input'] = search_input
         context['search_terms'] = search_terms
         context['search_projects'] = search_projects
-        context['search_type'] = search_type
         context['search_keywords'] = search_keywords
         # Get project results
-        if not search_type or search_type == 'project':
+        if search_keywords.get('type', 'project') == 'project':
             context['project_results'] = []
             for p in Project.objects.find(
                 search_terms,
@@ -940,12 +936,11 @@ class ProjectSearchResultsView(
             self.request.user,
             search_terms,
             search_projects,
-            search_type,
             search_keywords,
         )
         # List apps for which no results were found
         context['not_found'] = self._get_not_found(
-            search_type,
+            search_keywords.get('type', None),
             context.get('project_results') or [],
             context['app_results'],
         )

--- a/timeline/plugins.py
+++ b/timeline/plugins.py
@@ -115,8 +115,7 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
         search_terms: list[str],
         user: User,
         projects: QuerySet[Project],
-        search_type: Optional[str] = None,
-        keywords: Optional[dict] = None,
+        **kwargs: str,
     ) -> list[PluginSearchResult]:
         """
         Return app items based on one or more search terms, user, optional type
@@ -126,14 +125,13 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
                              (list of strings)
         :param user: User object for user initiating the search
         :param projects: QuerySet of projects where the terms are searched
-        :param search_type: String
-        :param keywords: Dictionary of key/value pairs (optional)
+        :param kwargs: Search options as key/value pairs (optional)
         :return: List of PluginSearchResult objects
         """
         items = []
-        if not search_type or search_type == 'timeline':
+        if kwargs.get('type', 'timeline') == 'timeline':
             events = list(
-                TimelineEvent.objects.find(search_terms, projects, keywords)
+                TimelineEvent.objects.find(search_terms, projects, kwargs)
             )
             items = [e for e in events if self._check_permission(user, e)]
         ret = PluginSearchResult(

--- a/timeline/plugins.py
+++ b/timeline/plugins.py
@@ -1,7 +1,5 @@
 """Plugins for the Timeline app"""
 
-from typing import Optional
-
 from django.contrib.auth import get_user_model
 from django.db.models import QuerySet
 

--- a/timeline/tests/test_plugins.py
+++ b/timeline/tests/test_plugins.py
@@ -302,7 +302,7 @@ class TestProjectAppPlugin(TimelinePluginTestBase):
             SEARCH_TERMS,
             self.user,
             Project.objects.all(),
-            search_type='timeline',
+            type='timeline',
         )
         self.assertEqual(len(ret[0].items), 1)
 
@@ -313,7 +313,7 @@ class TestProjectAppPlugin(TimelinePluginTestBase):
             SEARCH_TERMS,
             self.user,
             Project.objects.all(),
-            search_type='raTho0Oo',
+            type='raTho0Oo',
         )
         self.assertEqual(len(ret[0].items), 0)
 


### PR DESCRIPTION
This PR addresses #1901 and #1902. It should be rebased after #1903 is merged. I followed the spec pretty closely. In addition, I modified the templates as necessary. I wasn't sure whether to use `**kwargs` also for the find() methods in the model managers.