### PR TITLE
Add pseudonymization option to removeroles command

### DIFF
--- a/projectroles/management/commands/removeroles.py
+++ b/projectroles/management/commands/removeroles.py
@@ -145,7 +145,7 @@ class Command(
                 user.last_name = ''
                 user.email = ''
                 while True:
-                    random_username = 'deactivated_' + ''.join(
+                    random_username = 'deactivated' + ''.join(
                         random.choices(
                             string.ascii_lowercase + string.digits, k=12
                         )

--- a/projectroles/management/commands/removeroles.py
+++ b/projectroles/management/commands/removeroles.py
@@ -3,6 +3,8 @@ Removeroles management command for removing all roles from a user.
 """
 
 import sys
+import random
+import string
 
 from typing import Optional
 
@@ -34,7 +36,7 @@ class Command(
 ):
     help = (
         'Remove all roles from a user. Replace owner roles with given user or '
-        'parent owner.'
+        'parent owner. Optionally clear out all personal data.'
     )
 
     @classmethod
@@ -121,6 +123,40 @@ class Command(
             )
             return False
 
+    def _deactivate_user(
+        self, user: User, pseudonymize: bool, check: bool
+    ) -> bool:
+        """Deactivate a user, optionally removing their personal data"""
+        if check:
+            logger.info(f'User to be deactivated: {user.username}')
+        else:
+            user.is_active = False
+            user.save()
+            logger.info(f'User "{user.username}" deactivated')
+        if pseudonymize:
+            if check:
+                logger.info(
+                    "The user's name and email will be emptied, "
+                    'and the username will become a random string.'
+                )
+            else:
+                user.name = ''
+                user.first_name = ''
+                user.last_name = ''
+                user.email = ''
+                while True:
+                    random_username = 'deactivated_' + ''.join(
+                        random.choices(
+                            string.ascii_lowercase + string.digits, k=12
+                        )
+                    )
+                    try:
+                        User.objects.get(username=random_username)
+                    except User.DoesNotExist:
+                        user.username = random_username
+                        break
+                user.save()
+
     def add_arguments(self, parser):
         parser.add_argument(
             '-u',
@@ -145,6 +181,17 @@ class Command(
             default=False,
             action='store_true',
             help='Deactivate user after removing their roles',
+        )
+        parser.add_argument(
+            '-p',
+            '--pseudonymize',
+            dest='pseudonymize',
+            required=False,
+            default=False,
+            action='store_true',
+            help='Clear out all personal user data and replace the username '
+            'with a random string (this takes effect only if applied '
+            'together with --deactivate)',
         )
         parser.add_argument(
             '-c',
@@ -200,7 +247,6 @@ class Command(
         )
         if roles.count() == 0:
             logger.info('No roles found')
-            return
 
         for role_as in roles:
             project = role_as.project
@@ -220,12 +266,7 @@ class Command(
             elif not check:
                 fail_count += 1
         if options['deactivate']:
-            if check:
-                logger.info(f'User to be deactivated: {user.username}')
-            else:
-                user.is_active = False
-                user.save()
-                logger.info(f'User "{user.username}" deactivated')
+            self._deactivate_user(user, options['pseudonymize'], check)
         if check:
             logger.info('Check done')
         else:

--- a/projectroles/management/commands/removeroles.py
+++ b/projectroles/management/commands/removeroles.py
@@ -156,6 +156,7 @@ class Command(
                         user.username = random_username
                         break
                 user.save()
+                logger.info('All personal data were removed.')
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/projectroles/tests/test_commands.py
+++ b/projectroles/tests/test_commands.py
@@ -1,6 +1,7 @@
 """Tests for management commands in the projectroles app"""
 
 import os
+import random
 
 from tempfile import NamedTemporaryFile
 from typing import Union
@@ -1166,6 +1167,10 @@ class TestRemoveRoles(
         self.user_owner_cat = self.make_user('user_owner_cat')
         self.user_owner = self.make_user('user_owner')
         self.user = self.make_user('user')
+        self.user.first_name = 'Max'
+        self.user.last_name = 'Mustermann'
+        self.user.name = 'Max Mustermann'
+        self.user.save()
         # Init projects
         self.category = self.make_project(
             'TestCategory', PROJECT_TYPE_CATEGORY, None
@@ -1237,6 +1242,39 @@ class TestRemoveRoles(
         self.user.refresh_from_db()
         self.assertEqual(self.user.is_active, False)
 
+    def test_command_pseudonymize(self):
+        """Test user deactivation with pseudonymization"""
+        self.assertTrue(self.user.is_active)
+        call_command(
+            self.cmd_name, user=self.user, deactivate=True, pseudonymize=True
+        )
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+        self.assertEqual(self.user.name, '')
+        self.assertEqual(self.user.first_name, '')
+        self.assertEqual(self.user.last_name, '')
+        self.assertEqual(self.user.email, '')
+        self.assertTrue(self.user.username.startswith('deactivated'))
+
+    def test_command_pseudonymize_dupe_username(self):
+        """Test username pseudonymization with duplicates"""
+        random.seed(13)
+        call_command(
+            self.cmd_name, user=self.user, deactivate=True, pseudonymize=True
+        )
+        random.seed(13)
+        call_command(
+            self.cmd_name,
+            user=self.user_owner,
+            deactivate=True,
+            pseudonymize=True,
+        )
+        self.user.refresh_from_db()
+        self.user_owner.refresh_from_db()
+        self.assertTrue(self.user.username.startswith('deactivated'))
+        self.assertTrue(self.user_owner.username.startswith('deactivated'))
+        self.assertNotEqual(self.user.username, self.user_owner.username)
+
     @override_settings(PROJECTROLES_SITE_MODE=SITE_MODE_TARGET)
     def test_command_remote(self):
         """Test removing roles from remote project"""
@@ -1306,6 +1344,29 @@ class TestRemoveRoles(
         self.assertEqual(self.project.has_role(self.user), True)
         self.user.refresh_from_db()
         self.assertEqual(self.user.is_active, True)
+
+    def test_command_check_pseudonymize(self):
+        """Test command with check mode and pseudonymization"""
+        self.make_assignment(self.category, self.user, self.role_contributor)
+        self.make_assignment(self.project, self.user, self.role_guest)
+        self.assertEqual(self.category.has_role(self.user), True)
+        self.assertEqual(self.project.has_role(self.user), True)
+        self.assertEqual(self.user.is_active, True)
+        call_command(
+            self.cmd_name,
+            user=self.user,
+            check=True,
+            deactivate=True,
+            pseudonymize=True,
+        )
+        self.assertEqual(self.category.has_role(self.user), True)
+        self.assertEqual(self.project.has_role(self.user), True)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, True)
+        self.assertNotEqual(self.user.first_name, '')
+        self.assertNotEqual(self.user.last_name, '')
+        self.assertNotEqual(self.user.name, '')
+        self.assertNotEqual(self.user.email, '')
 
     def test_command_owner_unset(self):
         """Test removing owner with unset new owner"""


### PR DESCRIPTION
This PR addresses #1923. There is one departure from the original spec: I used `name` instead of `full_name` because the latter doesn't exist (which is confusing, because there is a `get_full_name()`).

While working on it, I noticed that users that have no roles are not deactivated (due to an early return statement). Thinking that we may want to pseudonymize them even if they have no roles, I went ahead and removed the return statement, but please let me know if we should update the logic.