### PR TITLE
Correctly set old_role in modify_assignment()

### DIFF
--- a/example_project_app/plugins.py
+++ b/example_project_app/plugins.py
@@ -400,7 +400,7 @@ class ProjectAppPlugin(ProjectModifyPluginMixin, ProjectAppPluginPoint):
             messages.info(
                 request,
                 EXAMPLE_ROLE_MODIFY_API_MSG.format(
-                    action=action.lower(),
+                    action=action,
                     old_role=old_role,
                     new_role=role_as.role,
                     user=role_as.user,

--- a/example_project_app/plugins.py
+++ b/example_project_app/plugins.py
@@ -12,7 +12,7 @@ from projectroles.app_settings import (
     get_example_setting_default,
     get_example_setting_options,
 )
-from projectroles.models import Project, SODAR_CONSTANTS
+from projectroles.models import Project, Role, RoleAssignment, SODAR_CONSTANTS
 from projectroles.plugins import (
     ProjectAppPluginPoint,
     ProjectModifyPluginMixin,
@@ -41,8 +41,11 @@ APP_SETTING_TYPE_JSON = SODAR_CONSTANTS['APP_SETTING_TYPE_JSON']
 APP_SETTING_TYPE_STRING = SODAR_CONSTANTS['APP_SETTING_TYPE_STRING']
 
 # Local constants
-EXAMPLE_MODIFY_API_MSG = (
+EXAMPLE_PROJECT_MODIFY_API_MSG = (
     'Example project app plugin API called from {project_type} {action}.'
+)
+EXAMPLE_ROLE_MODIFY_API_MSG = (
+    '{action} role from {old_role} to {new_role} for {user} in {project}.'
 )
 # Invalid app setting value for testing custom validation
 INVALID_SETTING_VALUE = 'INVALID VALUE'
@@ -350,7 +353,7 @@ class ProjectAppPlugin(ProjectModifyPluginMixin, ProjectAppPluginPoint):
     details_title = 'Example Project App Overview'
 
     #: Position in plugin ordering
-    plugin_ordering = 100
+    plugin_ordering = 110
 
     def get_statistics(self) -> dict:
         return {
@@ -379,10 +382,31 @@ class ProjectAppPlugin(ProjectModifyPluginMixin, ProjectAppPluginPoint):
         if request:
             messages.info(
                 request,
-                EXAMPLE_MODIFY_API_MSG.format(
+                EXAMPLE_PROJECT_MODIFY_API_MSG.format(
                     project_type=get_display_name(project.type),
                     action=action.lower(),
                 ),
+            )
+
+    def perform_role_modify(
+        self,
+        role_as: RoleAssignment,
+        action: str,
+        old_role: Optional[Role] = None,
+        request: Optional[HttpRequest] = None,
+    ):
+        """Example implementation for role assignment modifying plugin API"""
+        if request:
+            messages.info(
+                request,
+                EXAMPLE_ROLE_MODIFY_API_MSG.format(
+                    action=action.lower(),
+                    old_role=old_role,
+                    new_role=role_as.role,
+                    user=role_as.user,
+                    project=role_as.project,
+                ),
+                fail_silently=True,
             )
 
     def validate_form_app_settings(

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -90,6 +90,7 @@ from projectroles.views import (
     PROJECT_DELETE_CAT_ERR_MSG,
     PROJECT_DELETE_SOURCE_ERR_MSG,
     PROJECT_DELETE_TARGET_ERR_MSG,
+    PROJECT_ACTION_UPDATE,
 )
 from projectroles.context_processors import (
     SIDEBAR_ICON_MIN_SIZE,
@@ -4475,7 +4476,7 @@ class TestRoleAssignmentUpdateView(
         self.assertEqual(
             list(get_messages(response.wsgi_request))[0].message,
             EXAMPLE_ROLE_MODIFY_API_MSG.format(
-                action='update',
+                action=PROJECT_ACTION_UPDATE,
                 old_role=old_role,
                 new_role=self.role_contributor,
                 user=self.role_as.user,

--- a/projectroles/tests/test_views.py
+++ b/projectroles/tests/test_views.py
@@ -22,6 +22,8 @@ from test_plus.test import TestCase
 # Timeline dependency
 from timeline.models import TimelineEvent
 
+from example_project_app.plugins import EXAMPLE_ROLE_MODIFY_API_MSG
+
 from projectroles.app_settings import AppSettingAPI
 from projectroles.email import (
     get_email_user,
@@ -4453,6 +4455,34 @@ class TestRoleAssignmentUpdateView(
             mail.outbox[0].subject,
         )
 
+    def test_post_old_role(self):
+        """Test POST and check that old role is correct"""
+        data = {
+            'project': self.role_as.project.sodar_uuid,
+            'user': self.role_as.user.sodar_uuid,
+            'role': self.role_contributor.pk,
+        }
+        old_role = self.role_as.role
+        with self.login(self.user):
+            response = self.client.post(self.url, data)
+            self.assertRedirects(
+                response,
+                reverse(
+                    'projectroles:roles',
+                    kwargs={'project': self.project.sodar_uuid},
+                ),
+            )
+        self.assertEqual(
+            list(get_messages(response.wsgi_request))[0].message,
+            EXAMPLE_ROLE_MODIFY_API_MSG.format(
+                action='update',
+                old_role=old_role,
+                new_role=self.role_contributor,
+                user=self.role_as.user,
+                project=self.role_as.project,
+            ),
+        )
+
     def test_post_disable_alerts(self):
         """Test POST with disabled alert notifications"""
         app_settings.set(
@@ -5941,7 +5971,7 @@ class TestProjectInviteAcceptView(
             [(self.url_process_login, 302), (self.url_project, 302)],
         )
         self.assertEqual(
-            list(get_messages(response.wsgi_request))[0].message,
+            list(get_messages(response.wsgi_request))[1].message,
             PROJECT_WELCOME_MSG.format(
                 project_type='project',
                 project_title='TestProject',
@@ -6358,7 +6388,7 @@ class TestProjectInviteProcessNewUserView(
             response = self.client.get(self.url, follow=True)
         self.assertRedirects(response, self.url_project)
         self.assertEqual(
-            list(get_messages(response.wsgi_request))[0].message,
+            list(get_messages(response.wsgi_request))[1].message,
             PROJECT_WELCOME_MSG.format(
                 project_type='project',
                 project_title='TestProject',
@@ -6395,7 +6425,7 @@ class TestProjectInviteProcessNewUserView(
             ],
         )
         self.assertEqual(
-            list(get_messages(response.wsgi_request))[1].message, LOGIN_MSG
+            list(get_messages(response.wsgi_request))[2].message, LOGIN_MSG
         )
         user = User.objects.get(username='test')
         self.assertEqual(ProjectInvite.objects.filter(active=True).count(), 0)

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -2096,7 +2096,10 @@ class RoleAssignmentModifyMixin(ProjectModifyPluginViewMixin):
             role_as = RoleAssignment(project=project, user=user, role=role)
             old_role = None
         else:
-            role_as = instance
+            try:
+                role_as = RoleAssignment.objects.get(project=project, user=user)
+            except RoleAssignment.DoesNotExist:
+                role_as = project.get_role(user)
             old_role = role_as.role
             role_as.role = role
         role_as.save()

--- a/projectroles/views.py
+++ b/projectroles/views.py
@@ -2096,11 +2096,12 @@ class RoleAssignmentModifyMixin(ProjectModifyPluginViewMixin):
             role_as = RoleAssignment(project=project, user=user, role=role)
             old_role = None
         else:
-            try:
-                role_as = RoleAssignment.objects.get(project=project, user=user)
-            except RoleAssignment.DoesNotExist:
-                role_as = project.get_role(user)
-            old_role = role_as.role
+            role_as = instance
+            old_as = project.get_role(user)
+            if old_as and old_as.role != role_as.role:
+                old_role = old_as.role
+            else:
+                old_role = role_as.role
             role_as.role = role
         role_as.save()
 


### PR DESCRIPTION
This PR attempts to fix #1955. Instead of wrongly assuming that `instance` is the old role assignment, we try to get the actual `RoleAssignment` object, falling back to `project.get_role(user)` if the `get()` query fails (which can happen if the role is inherited).

As a regression test, I implemented the `perform_role_modify()` method in the `example_project_app` plugin. It sets a message so that we can check if `old_role` is assigned correctly.