### PR TITLE
Fix search results highlight for paginated tables

### DIFF
--- a/projectroles/static/projectroles/js/search.js
+++ b/projectroles/static/projectroles/js/search.js
@@ -161,6 +161,24 @@ function renderSearchResults(parentContainer, result, searchTerms) {
   const table = makeSearchResultsTable(result)
   cardBody.append(table)
 
+  /*********************
+   Cosmetic Improvements
+   *********************/
+
+  /* NOTE: these changes must be done before the DataTable is initialized,
+   * otherwise the table will be paginated and some rows may be removed from
+   * the DOM. Those rows will not be findable by these functions.
+   */
+
+  // Overflow status
+  modifyCellOverflow()
+  // Highlight search terms
+  highlightSearchResults(
+    table,
+    result.columns,
+    JSON.parse(searchTerms),
+  )
+
   /************************
    DataTable Initialization
    ************************/
@@ -176,7 +194,6 @@ function renderSearchResults(parentContainer, result, searchTerms) {
       unsearchableColumns.push(i)
     }
   }
-  console.log(unorderableColumns)
   const tableDT = $(table).DataTable({
     order: [], // Disable default ordering
     scrollX: false,
@@ -200,23 +217,11 @@ function renderSearchResults(parentContainer, result, searchTerms) {
     dom: 'tp',
   })
 
-  /*********************
-   Cosmetic Improvements
-   *********************/
-
-  // Overflow status
-  modifyCellOverflow()
   // Hide pagination and disable page dropdown if only one page
   if (tableDT.page.info().pages === 1) {
     card.find('.sodar-search-page-length').prop('disabled', 'disabled')
     $(table).next('.dt-paging').hide()
   }
-  // Highlight search terms
-  highlightSearchResults(
-    table,
-    result.columns,
-    JSON.parse(searchTerms),
-  )
 }
 
 function highlightSearchResults(table, columns, searchTerms) {

--- a/projectroles/tests/test_ui.py
+++ b/projectroles/tests/test_ui.py
@@ -1408,6 +1408,34 @@ class TestProjectSearchResultsView(SearchUITestMixin, ProjectUITestBase):
             '<strong class="sodar-search-highlight">Test</strong>Project',
         )
 
+    @override_settings(PROJECTROLES_SEARCH_PAGINATION=1)
+    def test_search_highlight_with_pagination(self):
+        """Test project search results highlight with pagination"""
+        url = self.url + '?' + urlencode({'s': 'test'})
+        self.make_project('TestProject2', PROJECT_TYPE_PROJECT, self.category)
+        self.login_and_redirect(
+            self.superuser, url, 'sodar-pr-search-table', 'CLASS_NAME'
+        )
+        # Go to the next page and check for highlight
+        next_page_button = self.selenium.find_element(
+            By.XPATH,
+            '//div[@class="sodar-ajax-search-results" and '
+            '@data-app-name="projectroles"]//a[@class="page-link next"]',
+        )
+        next_page_button.click()
+        name_cell = self.selenium.find_element(
+            By.CSS_SELECTOR,
+            '.sodar-pr-search-table tbody tr td:nth-child(1)',
+        )
+        name_content = name_cell.find_element(By.TAG_NAME, 'a').get_attribute(
+            'innerHTML'
+        )
+        self.assertEqual(
+            name_content,
+            '<strong class="sodar-search-highlight">Test</strong>Category / '
+            '<strong class="sodar-search-highlight">Test</strong>Project2',
+        )
+
     def test_search_order(self):
         """Test project search results orderable columns"""
         url = self.url + '?' + urlencode({'s': 'test'})


### PR DESCRIPTION
This PR addresses #1971. After initializing the `DataTable`, the table rows in page 2 and subsequent are removed from the DOM, so the jQuery selector used to find search terms could not find those rows. The same problem affected the `modifyCellOverflow()` function. With this PR, the calls to those functions are moved before initializing the `DataTable`, when all the cells are still in the DOM.